### PR TITLE
Fixed clipping of Atmosphere 

### DIFF
--- a/src/navigate/Navigator.js
+++ b/src/navigate/Navigator.js
@@ -111,9 +111,7 @@ define([
             // Compute the far clip distance based on the current eye altitude. This must be done after computing the
             // modelview matrix and before computing the near clip distance. The far clip distance depends on the
             // modelview matrix, and the near clip distance depends on the far clip distance.
-            this.farDistance = WWMath.horizonDistanceForGlobeRadius(globeRadius, eyePos.altitude);
-            if (this.farDistance < 1e3)
-                this.farDistance = 1e3;
+            this.farDistance = WWMath.horizonDistanceForGlobeRadius(globeRadius, eyePos.altitude) + 1.5e6;
 
             // Compute the near clip distance in order to achieve a desired depth resolution at the far clip distance.
             // This computed distance is limited such that it does not intersect the terrain when possible and is never


### PR DESCRIPTION
Adjusted the far clip plane to account for the atmosphere and above-ground placemarks beyond horizon. 

_Before the fix, notice black line on the horizon:_
![image](https://cloud.githubusercontent.com/assets/191515/25883387/110713c6-34ff-11e7-9bec-b9fdf00e6bc8.png)

_After the fix, atmosphere appears correct:_
![image](https://cloud.githubusercontent.com/assets/191515/25883398/2c8a5824-34ff-11e7-9439-4bcf13d624de.png)

_Sunrise/sunset effect works now:_
![image](https://cloud.githubusercontent.com/assets/191515/25883410/54485fa0-34ff-11e7-8895-b5caf8e57e5b.png)

_Placemarks now visible beyond the horizon:_
![image](https://cloud.githubusercontent.com/assets/191515/25883424/73c81528-34ff-11e7-99e3-5ea5d0ebbdf9.png)

