### PR TITLE
Fix incorrect passing of arguments in KMLMultiGeometry.

### DIFF
--- a/src/formats/kml/geom/KmlMultiGeometry.js
+++ b/src/formats/kml/geom/KmlMultiGeometry.js
@@ -74,11 +74,11 @@ define([
 	/**
      * @inheritDoc
      */
-    KmlMultiGeometry.prototype.render = function(dc) {
-        KmlGeometry.prototype.render.call(this, dc);
+    KmlMultiGeometry.prototype.render = function(dc, kmlOptions) {
+        KmlGeometry.prototype.render.call(this, dc, kmlOptions);
 
         this.kmlShapes.forEach(function(shape) {
-            shape.render(dc);
+            shape.render(dc, kmlOptions);
         });
     };
 


### PR DESCRIPTION
The KMLMultiGeometry was swallowing the additional kmlOptions parameter used during the rendering. 