### PR TITLE
Fix/BlueMarbleLayer refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ worldwind.min.js
 WebWorldWind.zip
 node_modules/
 test-results
+standalonedata/

--- a/GruntSetup.md
+++ b/GruntSetup.md
@@ -19,7 +19,7 @@ The below installations are per-project — must be performed with each new full
   `npm install grunt-contrib-requirejs`
 
 2) Install jsdoc 3.3.0 plugin (https://github.com/krampstudio/grunt-jsdoc)
-  `npm install grunt-jsdoc@beta`
+  `npm install grunt-jsdoc`
 
 3) Install compress plugin (https://github.com/gruntjs/grunt-contrib-compress)
   `npm install grunt-contrib-compress`

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -20,12 +20,14 @@ requirejs(['../src/WorldWind',
         backgroundLayer.hide = true; // Don't show it in the layer manager.
         wwd.addLayer(backgroundLayer);
 
-        // Create the Blue Marble layer and add it to the World Window's layer list. Disable it until its images
-        // are preloaded, which is initiated below.
-        var blueMarbleLayer = new WorldWind.BlueMarbleLayer(null, WorldWind.BlueMarbleLayer.availableTimes[0]);
-        blueMarbleLayer.enabled = false;
-        blueMarbleLayer.showSpinner = true;
-        wwd.addLayer(blueMarbleLayer);
+        // Create the Blue Marble time series layer.
+        var blueMarbleTimeSeries = new WorldWind.BMNGRestLayer(null);
+        blueMarbleTimeSeries.enabled = false;
+        blueMarbleTimeSeries.showSpinner = true;
+
+        // Add Blue Marble time series to the World Window's layer list. Disable it until its images are preloaded,
+        // which is initiated below.
+        wwd.addLayer(blueMarbleTimeSeries);
 
         // Create a compass and view controls.
         wwd.addLayer(new WorldWind.CompassLayer());
@@ -44,24 +46,24 @@ requirejs(['../src/WorldWind',
             if (!this.prePopulate) {
                 // Pre-populate the layer's sub-layers so that we don't see flashing of their image tiles as they're
                 // loaded.
-                blueMarbleLayer.prePopulate(wwd);
+                blueMarbleTimeSeries.prePopulate(wwd);
                 this.prePopulate = true;
                 return;
             }
 
             // See if the layer is pre-populated now. If so, enable it.
-            if (blueMarbleLayer.isPrePopulated(wwd)) {
-                blueMarbleLayer.enabled = true;
-                blueMarbleLayer.showSpinner = false;
+            if (blueMarbleTimeSeries.isPrePopulated(wwd)) {
+                blueMarbleTimeSeries.enabled = true;
+                blueMarbleTimeSeries.showSpinner = false;
                 window.clearInterval(prePopulateInterval);
                 layerManger.synchronizeLayerList();
 
                 // Increment the Blue Marble layer's time at a specified frequency.
                 var currentIndex = 0;
                 window.setInterval(function () {
-                    if (blueMarbleLayer.enabled) {
-                        currentIndex = ++currentIndex % WorldWind.BlueMarbleLayer.availableTimes.length;
-                        blueMarbleLayer.time = WorldWind.BlueMarbleLayer.availableTimes[currentIndex];
+                    if (blueMarbleTimeSeries.enabled) {
+                        currentIndex = ++currentIndex % WorldWind.BMNGRestLayer.availableTimes.length;
+                        blueMarbleTimeSeries.time = WorldWind.BMNGRestLayer.availableTimes[currentIndex];
                         wwd.redraw();
                     }
                 }, 200);

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -39,18 +39,78 @@
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_INFO);
 
         // Create a World Window for the canvas. Use a REST elevation model rather than the default.
-        var elevationModel = new WorldWind.EarthRestElevationModel(null, "../standalonedata/Earth/DTED0",
-                "Earth Elevations");
+        var elevationModel = new WorldWind.EarthRestElevationModel(null,
+                                                                   "../standalonedata/Earth/DTED0",
+                                                                   "Earth Elevations");
         var wwd = new WorldWind.WorldWindow("canvasOne", elevationModel);
 
-        // Add some REST image layers to the World Window's globe.
-        wwd.addLayer(new WorldWind.RestTiledImageLayer(null, "../standalonedata/Earth/BlueMarble256/BlueMarble-200404", "Blue Marble"));
-        wwd.addLayer(new WorldWind.LandsatRestLayer(null, "../standalonedata/Earth/Landsat", "LandSat"));
+        // Add some REST image layers to the World Window's globe:
+
+        // Blue Marble 2004 monthly time series.
+        var blueMarbleTimeSeries = new WorldWind.BMNGRestLayer(null,
+                                                               "../standalonedata/Earth/BlueMarble256/",
+                                                               "Blue Marble time series");
+
+        // Blue Marble layer equivalent to the April 2004 sublayer of the above,
+        // limited to the sector that roughly covers Europe.
+        var configuration = {
+            sector: new WorldWind.Sector(35, 65, -10, 45)
+        };
+
+        var blueMarbleFixed = new WorldWind.RestTiledImageLayer(null,
+                                                                "../standalonedata/Earth/BlueMarble256/BlueMarble-200404",
+                                                                "Blue Marble",
+                                                                configuration);
+
+        // Landsat layer (The data covers only a sector of the globe in North America)
+        var landSat = new WorldWind.LandsatRestLayer(null, "../standalonedata/Earth/Landsat", "LandSat");
+
+
+        // Disable the time series layer until it's pre-populated with its sub-layers
+        blueMarbleTimeSeries.enabled = false;
+
+        // Add all the layers to the World Window's layer list
+        wwd.addLayer(blueMarbleTimeSeries);
+        wwd.addLayer(blueMarbleFixed);
+        wwd.addLayer(landSat);
+
+        // Ensure that the background and other control layers are displayed while the time series layer is
+        // being pre-populated.
+        wwd.redraw();
 
         // Add a compass, a coordinates display and some view controls to the World Window.
         wwd.addLayer(new WorldWind.CompassLayer());
         wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));
         wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
+
+        // Wait for the time series layer to pre-populate all its sub-layers before enabling it.
+        var prePopulateInterval = window.setInterval(function () {
+            if (!this.prePopulate) {
+                // Pre-populate the layer's sub-layers so that we don't see flashing of their image tiles as they're
+                // loaded.
+                blueMarbleTimeSeries.prePopulate(wwd);
+                this.prePopulate = true;
+                return;
+            }
+
+            // See if the layer is pre-populated now. If so, enable it.
+            if (blueMarbleTimeSeries.isPrePopulated(wwd)) {
+                blueMarbleTimeSeries.enabled = true;
+                blueMarbleTimeSeries.showSpinner = false;
+                window.clearInterval(prePopulateInterval);
+                //layerManger.synchronizeLayerList();
+
+                // Increment the time series layer's time at a specified frequency.
+                var currentIndex = 0;
+                window.setInterval(function () {
+                    if (blueMarbleTimeSeries.enabled) {
+                        currentIndex = ++currentIndex % WorldWind.BMNGRestLayer.availableTimes.length;
+                        blueMarbleTimeSeries.time = WorldWind.BMNGRestLayer.availableTimes[currentIndex];
+                        wwd.redraw();
+                    }
+                }, 200);
+            }
+        }, 200);
     }
 </script>
 </body>

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -39,78 +39,25 @@
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_INFO);
 
         // Create a World Window for the canvas. Use a REST elevation model rather than the default.
-        var elevationModel = new WorldWind.EarthRestElevationModel(null,
-                                                                   "../standalonedata/Earth/DTED0",
-                                                                   "Earth Elevations");
+        var elevationModel = new WorldWind.EarthRestElevationModel(null, "../standalonedata/Earth/DTED0");
         var wwd = new WorldWind.WorldWindow("canvasOne", elevationModel);
 
         // Add some REST image layers to the World Window's globe:
 
-        // Blue Marble 2004 monthly time series.
-        var blueMarbleTimeSeries = new WorldWind.BMNGRestLayer(null,
-                                                               "../standalonedata/Earth/BlueMarble256/",
-                                                               "Blue Marble time series");
+        // Blue Marble Next Generation 2004
+        var blueMarble = new WorldWind.BMNGRestLayer(null, "../standalonedata/Earth/BlueMarble256/");
 
-        // Blue Marble layer equivalent to the April 2004 sublayer of the above,
-        // limited to the sector that roughly covers Europe.
-        var configuration = {
-            sector: new WorldWind.Sector(35, 65, -10, 45)
-        };
-
-        var blueMarbleFixed = new WorldWind.RestTiledImageLayer(null,
-                                                                "../standalonedata/Earth/BlueMarble256/BlueMarble-200404",
-                                                                "Blue Marble",
-                                                                configuration);
-
-        // Landsat layer (The data covers only a sector of the globe in North America)
+        // Landsat layer (The offline data covers only a sector of the globe in North America)
         var landSat = new WorldWind.LandsatRestLayer(null, "../standalonedata/Earth/Landsat", "LandSat");
 
-
-        // Disable the time series layer until it's pre-populated with its sub-layers
-        blueMarbleTimeSeries.enabled = false;
-
         // Add all the layers to the World Window's layer list
-        wwd.addLayer(blueMarbleTimeSeries);
-        wwd.addLayer(blueMarbleFixed);
+        wwd.addLayer(blueMarble);
         wwd.addLayer(landSat);
-
-        // Ensure that the background and other control layers are displayed while the time series layer is
-        // being pre-populated.
-        wwd.redraw();
 
         // Add a compass, a coordinates display and some view controls to the World Window.
         wwd.addLayer(new WorldWind.CompassLayer());
         wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));
         wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
-
-        // Wait for the time series layer to pre-populate all its sub-layers before enabling it.
-        var prePopulateInterval = window.setInterval(function () {
-            if (!this.prePopulate) {
-                // Pre-populate the layer's sub-layers so that we don't see flashing of their image tiles as they're
-                // loaded.
-                blueMarbleTimeSeries.prePopulate(wwd);
-                this.prePopulate = true;
-                return;
-            }
-
-            // See if the layer is pre-populated now. If so, enable it.
-            if (blueMarbleTimeSeries.isPrePopulated(wwd)) {
-                blueMarbleTimeSeries.enabled = true;
-                blueMarbleTimeSeries.showSpinner = false;
-                window.clearInterval(prePopulateInterval);
-                //layerManger.synchronizeLayerList();
-
-                // Increment the time series layer's time at a specified frequency.
-                var currentIndex = 0;
-                window.setInterval(function () {
-                    if (blueMarbleTimeSeries.enabled) {
-                        currentIndex = ++currentIndex % WorldWind.BMNGRestLayer.availableTimes.length;
-                        blueMarbleTimeSeries.time = WorldWind.BMNGRestLayer.availableTimes[currentIndex];
-                        wwd.redraw();
-                    }
-                }, 200);
-            }
-        }, 200);
     }
 </script>
 </body>

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -21,10 +21,10 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         './layer/BingAerialWithLabelsLayer',
         './layer/BingRoadsLayer',
         './layer/BingWMSLayer',
-        './layer/BlueMarbleLayer',
         './layer/BMNGLandsatLayer',
         './layer/BMNGLayer',
         './layer/BMNGOneImageLayer',
+        './layer/BMNGRestLayer',
         './geom/BoundingBox',
         './gesture/ClickRecognizer',
         './formats/collada/ColladaLoader',
@@ -245,10 +245,10 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
               BingAerialWithLabelsLayer,
               BingRoadsLayer,
               BingWMSLayer,
-              BlueMarbleLayer,
               BMNGLandsatLayer,
               BMNGLayer,
               BMNGOneImageLayer,
+              BMNGRestLayer,
               BoundingBox,
               ClickRecognizer,
               ColladaLoader,
@@ -678,10 +678,10 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         WorldWind['BingAerialWithLabelsLayer'] = BingAerialWithLabelsLayer;
         WorldWind['BingRoadsLayer'] = BingRoadsLayer;
         WorldWind['BingWMSLayer'] = BingWMSLayer;
-        WorldWind['BlueMarbleLayer'] = BlueMarbleLayer;
         WorldWind['BMNGLandsatLayer'] = BMNGLandsatLayer;
         WorldWind['BMNGLayer'] = BMNGLayer;
         WorldWind['BMNGOneImageLayer'] = BMNGOneImageLayer;
+        WorldWind['BMNGRestLayer'] = BMNGRestLayer;
         WorldWind['BoundingBox'] = BoundingBox;
         WorldWind['ClickRecognizer'] = ClickRecognizer;
         WorldWind['ColladaLoader'] = ColladaLoader;


### PR DESCRIPTION
BlueMarbleLayer refactored into BMNGRestLayer. 

 - BlueMarbleLayer name changed into BMNGRestLayer since the former
   was sometimes confused with BMNGLayer as the most regularly used
   layer based off Blue Marble Next Generation imagery.
 - The above class was modified in its constructor in order to be more
   in line with the other 'Rest-' layers. Now it can receive parameters
   regarding server address and path for data retrieval. Now it can be
   configured to retrieve its imagery either from worldwindserver.net
   (by default) or from a local folder.

 Two examples are making use of this layer:

 - The BlueMarbleTimeSeries example now retrieves its data from NASA's
   server, so it works 'right out of the box' without the need to
   download the standalone data package from World Wind server.
 - The 'Standalone' example now makes use of BMNGRestLayer configured
   to retrieve its data from a local folder.

Reverted Standalone example to simpler version with BMNGRestLayer

 - Removed previous RestTiledImageLayer, since it was rendered redundant
   with the new BMNGRestLayer.

 - Simplified usage of BMNGRestLayer, removing code related to making it
   work as a time series. This use case is covered in the
   BlueMarbleTimeSeries example.

Regarding documentation:

 - Corrected outdated reference in GruntSetup guide. JSDocs is no longer
   in beta.

 Related to issue #125 