### PR TITLE
Align visual width of SurfacePolyline and Path for the same outlineWidth

### DIFF
--- a/src/shapes/SurfaceShape.js
+++ b/src/shapes/SurfaceShape.js
@@ -818,7 +818,7 @@ define([
                 }
                 if (drawOutline) {
                     this.draw(this._outlineGeometry, ctx2D, xScale, yScale, dx, dy);
-                    ctx2D.lineWidth = 4 * attributes.outlineWidth;
+                    ctx2D.lineWidth = attributes.outlineWidth;
                     ctx2D.strokeStyle = dc.pickingMode ? pickColor : attributes.outlineColor.toRGBAString();
                     ctx2D.stroke();
                 }


### PR DESCRIPTION
I tried for different SurfaceShapes and currently, it seems to work as expected. 