### PR TITLE
Added CommonJS-like interface to almond wrapper.

### DIFF
--- a/tools/wrap.start
+++ b/tools/wrap.start
@@ -1,5 +1,5 @@
 (function (root, factory) {
-    if (typeof exports === "object"){
+    if (typeof exports === "object") {
         // CommonJS-like
         module.exports = factory();
     } else if (typeof define === 'function' && define.amd) {

--- a/tools/wrap.start
+++ b/tools/wrap.start
@@ -1,5 +1,8 @@
 (function (root, factory) {
-    if (typeof define === 'function' && define.amd) {
+    if (typeof exports === "object"){
+        // CommonJS-like
+        module.exports = factory();
+    } else if (typeof define === 'function' && define.amd) {
         // AMD.
         define([], factory);
     } else {
@@ -7,5 +10,4 @@
         root.WorldWind = factory();
     }
 }(this, function () {
-
 


### PR DESCRIPTION
 - This changes the build artifact generation so it has a UMD interface.
   http://davidbcalhoun.com/2014/what-is-amd-commonjs-and-umd/

 - Build artifacts should now be capable of interfacing like Node modules
   ( with a bundler like Webpack or Browserify for
   frontend development), in addition to the previous interfaces
   (an AMD module or web browser object attached to the window object).

Closes #151 