### PR TITLE
WebStorm project cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,8 @@
 .DS_Store
 
-.idea/encodings.xml
-
-.idea/modules.xml
-
-.idea/misc.xml
-
 .idea/shelf
+
+.idea/tasks.xml
 
 .idea/workspace.xml
 

--- a/.idea/WebWorldWind.iml
+++ b/.idea/WebWorldWind.iml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/api-doc" />
+      <excludeFolder url="file://$MODULE_DIR$/test-results" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>


### PR DESCRIPTION
- Eliminates spurious changes to project files from WebStorm automatic changes.
- Excluded build output from WebStorm project search paths.
- Updated .gitignore for project files per IntelliJ guidelines:
https://intellij-support.jetbrains.com/hc/en-us/articles/206544839-How-to-manage-projects-under-Version-Control-Systems