### PR TITLE
Shim file entry reference removed since 'worldwind.min.js' works now.

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@nasaworldwind/worldwind",
   "version": "0.0.1",
   "description": "Web WorldWind",
-  "main": "index.js",
+  "main": "worldwind.min.js",
   "homepage": "https://nasaworldwind.github.io/",
   "bugs": {
     "url": "https://github.com/NASAWorldWind/WebWorldWind/issues"


### PR DESCRIPTION
### Description of the Change
Due to module definition discrepancies, a shim file was introduced to enable scoped npm package support, as described in #171. These discrepancies were finally solved in #202, and this eliminated the need for a shim file. No additional changes were needed besides using our usual 'worldwind.min.js' as the package entry point. The purpose of this pull request is mainly to document how the package was tested, and to invite to test it within other projects.

The shim file itself was removed earlier.

Successful tests with the package produced with the current code can be seen here:

- With Browserify as its bundling tool: https://github.com/Beak-man/worldwind-browserify-test
- With Webpack as bundler (within a React project): https://github.com/Beak-man/worldwind-react

Another example with Angular (with Webpack) will be added in the future.

It can be tested by producing the package with:
`> npm pack`
Then the file produced ('nasaworldwind-worldwind-0.0.1.tgz'), can be copied to another npm-enabled project, alongside its 'package.json' file. Then we install with:
`> npm install nasaworldwind-worldwind-0.0.1.tgz`

The package can be loaded within the project with:
````javascript
require('@nasaworldwind/worldwind')
````
or
````javascript
import WorldWind from '@nasaworldwind/worldwind'
````
depending on the module definitions available for the project.

### Why Should This Be In Core?
This change finally permits Web WorldWind to function as a scoped npm package, with no shim file, setting the stage to publish the package in npm's repository via CI.

### Benefits
Less potential confusion regarding the production of artifacts, npm package entry point, and library interfacing in general.

### Potential Drawbacks
No drawbacks, considering that the presence of the shim reference was by itself a drawback.

### Applicable Issues
Closes #206