### PR TITLE
Add npm publishing capability

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -39,3 +39,5 @@ test/
 test-results/
 
 tools/
+
+travis/

--- a/.npmignore
+++ b/.npmignore
@@ -12,6 +12,8 @@ apps/
 
 config.json
 
+CONTRIBUTING.md
+
 design-notes/
 
 examples/
@@ -22,6 +24,8 @@ HowToBuildWebWW.md
 
 HowToCreateAndRunUnitTests.md
 
+ISSUE_TEMPLATE.md
+
 karma.conf.js
 
 layout.tmpl
@@ -31,6 +35,8 @@ node_modules/
 package-lock.json
 
 performance/
+
+PULL_REQUEST_TEMPLATE.md
 
 src/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,12 @@ node_js:
 script:
   - npm run build
 
-# Node.js build cache configuration. See the Travis CI documentation: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Caching-with-npm
-cache:
-  directories:
-    - "node_modules"
-
+# Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:
-  # Publish to npm repository
+  # Publish release artifacts to the npm repository
   - provider: npm
     email: $NPM_EMAIL
-    api_key: $NPM_KEY
+    api_key: $NPM_API_KEY
     skip_cleanup: true
     on:
       tags: true
@@ -38,3 +34,8 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+
+# Node.js build cache configuration. See the Travis CI documentation: https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Caching-with-npm
+cache:
+  directories:
+    - "node_modules"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,25 @@ script:
 cache:
   directories:
     - "node_modules"
+
+deploy:
+  # Publish to npm repository
+  - provider: npm
+    email: $NPM_EMAIL
+    api_key: $NPM_KEY
+    skip_cleanup: true
+    on:
+      tags: true
+  # Create CHANGELOG.md in the current directory
+  - provider: script
+    script: ./travis/changelog.sh >> CHANGELOG.md
+    skip_cleanup: true
+    on:
+      tags: true
+  # Create a GitHub release and publish CHANGELOG.md to the release assets
+  - provider: releases
+    api_key: $GITHUB_API_KEY
+    file: CHANGELOG.md
+    skip_cleanup: true
+    on:
+      tags: true

--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "javascript",
     "webgl",
     "browser"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/travis/changelog.sh
+++ b/travis/changelog.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Writes a change log to stdout using the GitHub API and the milestone associated with the specified Git tag
+
+# Write Markdown headers for the Git tag and release date
+echo "## ${TRAVIS_TAG}"
+echo "###### Released on $(date '+%Y-%m-%d')"
+
+# Query GitHub API for a milestone matching the Git tag
+GITHUB_API_URL="https://api.github.com/repos/${TRAVIS_REPO_SLUG}"
+MILESTONE_ARRAY=( \
+    $(curl --silent "${GITHUB_API_URL}/milestones?state=all" \
+    | jq --arg title "${TRAVIS_TAG}" '.[] | select(.title | contains($title)) | .number') \
+    ) > /dev/null
+
+# When GitHub has a milestone matching the Git tag, write milestone related information to the change log
+if [[ "${#MILESTONE_ARRAY[@]}" -ne 0 ]]; then
+    # Write the milestone description to the change log
+    MILESTONE_DESCRIPTION=( \
+        $(curl --silent "${GITHUB_API_URL}/milestones/${MILESTONE_ARRAY[0]}" \
+        | jq .description --raw-output) \
+        ) > /dev/null
+    echo "${MILESTONE_DESCRIPTION[*]}"
+
+    # Write the milestone's associated issues to the change log with each issue on a separate line with the issue
+    # title, issue number, and a link to the issue on GitHub.com, all in markdown format: .title ([#.number](.html_url))
+    ISSUE_ARRAY=$(curl --silent "${GITHUB_API_URL}/issues?state=all&milestone=${MILESTONE_ARRAY[0]}" | jq -c '.[] | [.title, .number, .html_url]') >> /dev/null
+    while read line
+    do
+        echo ${line} | sed 's#\["\(.*\)",\(.*\),"\(.*\)"\]#- \1 [\#\2](\3)#'
+    done <<< "${ISSUE_ARRAY[*]}"
+fi


### PR DESCRIPTION
### Description of the Change

This change adds the tasks to the travis configuration file to publish the package to the npm registry. Additionally, the creation and upload of a CHANGELOG has been added. The condition for publishing is based on a tag.

*In addition to the changes in this pull request, additional environment variables are required in travis-ci.org*

### Why Should This Be In Core?

Automates deployment/publishing of releases to the npm repository.

### Applicable Issues

#152 