### PR TITLE
Use default style when none is provided.

### DIFF
--- a/src/formats/kml/features/KmlFeature.js
+++ b/src/formats/kml/features/KmlFeature.js
@@ -311,7 +311,7 @@ define([
      * @return {Promise|undefined} Promise of the file to deliver
      */
     KmlFeature.prototype.getStyle = function (dc, kmlOptions) {
-        if (this._pStyle || (!this.kmlStyleUrl && !this.kmlStyleSelector)) {
+        if (this._pStyle) {
             return;
         }
 

--- a/src/formats/kml/styles/KmlStyle.js
+++ b/src/formats/kml/styles/KmlStyle.js
@@ -249,5 +249,15 @@ define([
         return attributes;
     };
 
+    /**
+     * It returns default KmlStyle, which doesn't contain any custom information.
+     * @returns {KmlStyle}
+     */
+    KmlStyle.default = function() {
+        return new KmlStyle({
+            objectNode: document.createElement('Style')
+        });
+    };
+
     return KmlStyle;
 });

--- a/src/formats/kml/util/StyleResolver.js
+++ b/src/formats/kml/util/StyleResolver.js
@@ -4,8 +4,10 @@
  */
 define([
     '../KmlFile',
+    '../styles/KmlStyle',
     '../../../util/Logger'
 ], function (KmlFile,
+             KmlStyle,
              Logger) {
     "use strict";
 
@@ -32,6 +34,7 @@ define([
             this.handleStyleSelector(styleSelector, resolve, reject);
         } else {
             Logger.logMessage(Logger.LEVEL_WARNING, "StyleResolver", "handleRemoteStyle", "Style was null.");
+            resolve(KmlStyle.default());
         }
     };
 


### PR DESCRIPTION
### Description of the Change

When a KML Element doesn't provide any style, the default style should be used.

### Why Should This Be In Core?

It is part of the KML specification and we already had a related bug.

### Benefits

It allows a wider amount of KML files to be displayed.

### Potential Drawbacks

### Applicable Issues

Not working WFS exports from the GeoServer