### PR TITLE
Create distribution folder for generated assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ nasaworldwind-worldwind-*.tgz
 
 node_modules/
 
+npm-debug.log
+
 standalonedata/
 
 test-results/

--- a/.gitignore
+++ b/.gitignore
@@ -6,11 +6,9 @@
 
 .idea/workspace.xml
 
-api-doc/
-
 assetsToPublish/
 
-images.zip
+dist/
 
 nasaworldwind-worldwind-*.tgz
 
@@ -19,7 +17,3 @@ node_modules/
 standalonedata/
 
 test-results/
-
-worldwind.js
-
-worldwind.min.js

--- a/.idea/WebWorldWind.iml
+++ b/.idea/WebWorldWind.iml
@@ -2,8 +2,10 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
-      <excludeFolder url="file://$MODULE_DIR$/api-doc" />
+      <excludeFolder url="file://$MODULE_DIR$/dist" />
       <excludeFolder url="file://$MODULE_DIR$/test-results" />
+      <excludePattern pattern="nasaworldwind-worldwind-*.tgz" />
+      <excludePattern pattern="npm-debug.log" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,7 +11,7 @@ module.exports = function (grunt) {
             dist: {
                 src: ['src'],
                 options: {
-                    destination: 'api-doc',
+                    destination: 'dist/api-doc',
                     configure: 'config.json',
                     readme: 'README.md',
                     recurse: true
@@ -25,7 +25,7 @@ module.exports = function (grunt) {
                     baseUrl: 'src',
                     name: '../tools/almond',
                     include: ['WorldWind'],
-                    out: 'worldwind.min.js',
+                    out: 'dist/worldwind.min.js',
                     wrap: {
                         startFile: 'tools/wrap.start',
                         endFile: 'tools/wrap.end'
@@ -38,7 +38,7 @@ module.exports = function (grunt) {
                     name: '../tools/almond',
                     include: ['WorldWind'],
                     optimize: 'none',
-                    out: 'worldwind.js',
+                    out: 'dist/worldwind.js',
                     wrap: {
                         startFile: 'tools/wrap.start',
                         endFile: 'tools/wrap.end'
@@ -65,19 +65,44 @@ module.exports = function (grunt) {
         compress: {
             main: {
                 options: {
-                    archive: 'images.zip'
+                    archive: 'dist/images.zip'
                 },
                 files: [
                     {src: ['images/**']}
+                ]
+            }
+        },
+
+        copy: {
+            main: {
+                files: [
+                    // Copy all of the files in the examples folder except the current shim which uses the sources files
+                    {
+                        expand: true,
+                        src: ['images/**', 'examples/**', '!examples/WorldWindShim\.js', 'README.md', 'LICENSE.txt'],
+                        dest: 'dist/'
+                    },
+                    // Copy and rename the deployment WorldWindShim which uses the minified library
+                    {
+                        expand: true,
+                        cwd: 'tools',
+                        src: ['WorldWindShim.build.js'],
+                        dest: 'dist/examples/',
+                        rename: function (dest, src) {
+                            return dest + src.replace('WorldWindShim.build', 'WorldWindShim');
+                        }
+                    }
                 ]
             }
         }
     });
 
     grunt.loadNpmTasks('grunt-contrib-compress');
+    grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-requirejs');
     grunt.loadNpmTasks('grunt-jsdoc');
     grunt.loadNpmTasks('grunt-karma');
 
     grunt.registerTask('default', ['karma', 'jsdoc', 'requirejs', 'compress']);
+    grunt.registerTask('dist', ['jsdoc', 'requirejs', 'copy']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -62,6 +62,11 @@ module.exports = function (grunt) {
             }
         },
 
+        clean: [
+            'dist/',
+            'assetsToPublish/'
+        ],
+
         compress: {
             main: {
                 options: {
@@ -97,6 +102,7 @@ module.exports = function (grunt) {
         }
     });
 
+    grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-contrib-compress');
     grunt.loadNpmTasks('grunt-contrib-copy');
     grunt.loadNpmTasks('grunt-contrib-requirejs');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ module.exports = function (grunt) {
                     // Copy all of the files in the examples folder except the current shim which uses the sources files
                     {
                         expand: true,
-                        src: ['images/**', 'examples/**', '!examples/WorldWindShim\.js', 'README.md', 'LICENSE.txt'],
+                        src: ['images/**', 'examples/**', '!examples/WorldWindShim.js', 'README.md', 'LICENSE.txt'],
                         dest: 'dist/'
                     },
                     // Copy and rename the deployment WorldWindShim which uses the minified library

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,8 +63,7 @@ module.exports = function (grunt) {
         },
 
         clean: [
-            'dist/',
-            'assetsToPublish/'
+            'dist/'
         ],
 
         compress: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -109,6 +109,5 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-jsdoc');
     grunt.loadNpmTasks('grunt-karma');
 
-    grunt.registerTask('default', ['karma', 'jsdoc', 'requirejs', 'compress']);
-    grunt.registerTask('dist', ['jsdoc', 'requirejs', 'copy']);
+    grunt.registerTask('default', ['clean', 'karma', 'jsdoc', 'requirejs', 'compress', 'copy']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,7 +63,8 @@ module.exports = function (grunt) {
         },
 
         clean: [
-            'dist/'
+            'dist/',
+            'test-results/'
         ],
 
         compress: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2188,6 +2188,33 @@
         }
       }
     },
+    "grunt-contrib-clean": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-clean/-/grunt-contrib-clean-1.1.0.tgz",
+      "integrity": "sha1-Vkq/LQN4qYOhW54/MO51tzjEBjg=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+          "dev": true
+        },
+        "rimraf": {
+          "version": "2.6.2",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "dev": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        }
+      }
+    },
     "grunt-contrib-compress": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/grunt-contrib-compress/-/grunt-contrib-compress-1.4.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -841,6 +841,12 @@
         "is-extglob": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
       }
     },
+    "file-sync-cmp": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
+      "integrity": "sha1-peeo/7+kk7Q7kju9TKiaU7Y7YSs=",
+      "dev": true
+    },
     "filename-regex": {
       "version": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
@@ -2194,6 +2200,16 @@
         "lodash": "4.17.4",
         "pretty-bytes": "4.0.2",
         "stream-buffers": "2.2.0"
+      }
+    },
+    "grunt-contrib-copy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
+      "integrity": "sha1-cGDGWB6QS4qw0A8HbgqPbj58NXM=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "file-sync-cmp": "0.1.1"
       }
     },
     "grunt-contrib-requirejs": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "devDependencies": {
     "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.1.0",
     "grunt-contrib-compress": "^1.4.3",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-requirejs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "scripts": {
     "build": "grunt",
+    "clean": "grunt clean",
     "test": "grunt karma",
     "doc": "grunt jsdoc",
     "test:watch": "karma start karma.conf.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@nasaworldwind/worldwind",
   "version": "0.0.1",
   "description": "Web WorldWind",
-  "main": "worldwind.min.js",
+  "main": "dist/worldwind.min.js",
   "homepage": "https://nasaworldwind.github.io/",
   "bugs": {
     "url": "https://github.com/NASAWorldWind/WebWorldWind/issues"
@@ -13,12 +13,6 @@
     "NASA Project Manager <patrick.hogan@nasa.gov>",
     "ESA Consortium Contact <yann.voumard@solenix.ch>"
   ],
-  "directories": {
-    "lib": "./src",
-    "doc": "./api-doc",
-    "test": "./test",
-    "example": "./examples"
-  },
   "repository": {
     "type": "git",
     "url": "https://github.com/NASAWorldWind/WebWorldWind.git"
@@ -30,14 +24,15 @@
     "test:watch": "karma start karma.conf.js"
   },
   "files": [
-    "images/",
-    "images.zip",
-    "worldwind.js",
-    "worldwind.min.js"
+    "dist/images/",
+    "dist/images.zip",
+    "dist/worldwind.js",
+    "dist/worldwind.min.js"
   ],
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-contrib-compress": "^1.4.3",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-requirejs": "^1.0.0",
     "grunt-jsdoc": "^2.1.0",
     "grunt-karma": "^2.0.0",

--- a/tools/WorldWindShim.build.js
+++ b/tools/WorldWindShim.build.js
@@ -1,0 +1,11 @@
+/**
+ * This shim is used to switch between the individual WorldWind source files and the minified single file library for
+ * the WorldWind module. Switching allows locally developed examples to run from the individual WorldWind source files
+ * and hosted examples to use the faster to download minified library. A shim is not required for the use of WorldWind.
+ * The minified library (worldwind.min.js) is recommended for use in deployed applications.
+ */
+define(['../worldwind.min.js'], function (WorldWind) {
+    "use strict";
+
+    return WorldWind;
+});

--- a/travis/publishToArtifactory.sh
+++ b/travis/publishToArtifactory.sh
@@ -3,4 +3,4 @@
 mkdir assetsToPublish
 NPM_PACKAGE=$(npm pack)
 tar -xf $NPM_PACKAGE -C ./assetsToPublish --strip-components 2
-node travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./assetsToPublish /artifactory/generic-local/${TRAVIS_TAG#"v"}
+node travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./assetsToPublish /artifactory/web/${TRAVIS_TAG#"v"}

--- a/travis/publishToArtifactory.sh
+++ b/travis/publishToArtifactory.sh
@@ -2,5 +2,5 @@
 
 mkdir assetsToPublish
 NPM_PACKAGE=$(npm pack)
-tar -xf $NPM_PACKAGE -C ./assetsToPublish --strip-components 1
-node travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./assetsToPublish /artifactory/web/${TRAVIS_TAG#"v"}
+tar -xf $NPM_PACKAGE -C ./assetsToPublish --strip-components 2
+node travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./assetsToPublish /artifactory/generic-local/${TRAVIS_TAG#"v"}


### PR DESCRIPTION
Closes #280 
Closes #276 (approach incorporated into this pr)

This pull requests adds several grunt tasks which:

1. Send build artifacts (api-docs, libraries) to a directory named `dist`
2. Copies examples and the deployment shim file (see #275) to `dist`
3. Adds a `clean` task to remove `dist` and `assetsToPublish`

By publishing the client consumable artifacts to a single directory we can better package and provide the library without the requirement of npm.