### PR TITLE
Utilize time property of layer to determine sun location on Atmosphere Layer

### DIFF
--- a/examples/Atmosphere.js
+++ b/examples/Atmosphere.js
@@ -25,8 +25,9 @@ requirejs(['./WorldWindShim',
             wwd.addLayer(layers[l].layer);
         }
         
-        var lightLocation = new WorldWind.Position(19, 20, 0);
         var atmosphereLayer = new WorldWind.AtmosphereLayer();
+        var timeStamp = Date.now();
+        atmosphereLayer.time = new Date(timeStamp);
         wwd.addLayer(atmosphereLayer);
 
         // Create a layer manager for controlling layer visibility.
@@ -41,7 +42,7 @@ requirejs(['./WorldWindShim',
                 runSunSimulation();
             }
             else {
-                atmosphereLayer.lightLocation = null;
+                atmosphereLayer.time = null;
                 clearInterval(sunInterval);
                 wwd.redraw();
             }
@@ -49,8 +50,8 @@ requirejs(['./WorldWindShim',
 
         function runSunSimulation() {
             sunInterval = setInterval(function () {
-                atmosphereLayer.lightLocation = lightLocation;
-                lightLocation.longitude += 3;
+                timeStamp += 180 * 1000;
+                atmosphereLayer.time = new Date(timeStamp);
                 wwd.redraw();
             }, 64);
         }

--- a/examples/StarField.js
+++ b/examples/StarField.js
@@ -24,8 +24,9 @@ requirejs([
         wwd.addLayer(starFieldLayer);
         wwd.addLayer(atmosphereLayer);
 
-        starFieldLayer.time = new Date();
-        atmosphereLayer.lightLocation = WorldWind.SunPosition.getAsGeographicLocation(starFieldLayer.time);
+        var date = new Date();
+        starFieldLayer.time = date;
+        atmosphereLayer.time = date;
 
         var layerManger = new LayerManager(wwd);
         wwd.redraw();
@@ -42,8 +43,9 @@ requirejs([
         function onSunCheckBoxClick() {
             doRunSimulation = this.checked;
             if (!doRunSimulation) {
-                starFieldLayer.time = new Date();
-                atmosphereLayer.lightLocation = WorldWind.SunPosition.getAsGeographicLocation(starFieldLayer.time);
+                var date = new Date();
+                starFieldLayer.time = date;
+                atmosphereLayer.time = date;
             }
             wwd.redraw();
         }
@@ -51,8 +53,9 @@ requirejs([
         function runSunSimulation(wwd, stage) {
             if (stage === WorldWind.AFTER_REDRAW && doRunSimulation) {
                 timeStamp += (factor * 60 * 1000);
-                starFieldLayer.time = new Date(timeStamp);
-                atmosphereLayer.lightLocation = WorldWind.SunPosition.getAsGeographicLocation(starFieldLayer.time);
+                var date = new Date(timeStamp);
+                starFieldLayer.time = date;
+                atmosphereLayer.time = date;
                 wwd.redraw();
             }
         }

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -49,9 +49,6 @@ define([
             this._nightImageSource = nightImageSource ||
                 WorldWind.configuration.baseUrl + 'images/dnb_land_ocean_ice_2012.png';
 
-            //Documented in defineProperties below.
-            this._lightLocation = null;
-
             //Internal use only.
             //The light direction in cartesian space, computed form the lightLocation or defaults to the eyePoint.
             this._activeLightDirection = new Vec3(0, 0, 0);

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -210,8 +210,8 @@ define([
 
             program.setScale(gl);
 
-            // Use this layer's night image when the light location is different than the eye location.
-            if (this.nightImageSource && this.time) {
+            // Use this layer's night image when the layer has time value defined
+            if (this.nightImageSource && (this.time !== null)) {
                 
                 this._activeTexture = dc.gpuResourceCache.resourceForKey(this.nightImageSource);
                 

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -82,21 +82,6 @@ define([
         Object.defineProperties(AtmosphereLayer.prototype, {
 
             /**
-             * The geographic location of the light (sun). If the Layer time property is set, this location will be
-             * overriden to reflect the location of the sun at the specified time.
-             * @memberof AtmosphereLayer.prototype
-             * @type {Position}
-             */
-            lightLocation: {
-                get: function () {
-                    return this._lightLocation;
-                },
-                set: function (value) {
-                    this._lightLocation = value;
-                }
-            },
-
-            /**
              * Url for the night texture.
              * @memberof AtmosphereLayer.prototype
              * @type {URL}
@@ -229,7 +214,7 @@ define([
             program.setScale(gl);
 
             // Use this layer's night image when the light location is different than the eye location.
-            if (this.nightImageSource && this.lightLocation) {
+            if (this.nightImageSource && this.time) {
                 
                 this._activeTexture = dc.gpuResourceCache.resourceForKey(this.nightImageSource);
                 
@@ -323,11 +308,8 @@ define([
         // Internal. Intentionally not documented.
         AtmosphereLayer.prototype.determineLightDirection = function (dc) {
             if (this.time !== null) {
-                this.lightLocation = SunPosition.getAsGeographicLocation(this.time);
-            }
-
-            if (this.lightLocation) {
-                dc.globe.computePointFromLocation(this.lightLocation.latitude, this.lightLocation.longitude,
+                var sunLocation = SunPosition.getAsGeographicLocation(this.time);
+                dc.globe.computePointFromLocation(sunLocation.latitude, sunLocation.longitude,
                     this._activeLightDirection);
             } else {
                 this._activeLightDirection.copy(dc.navigatorState.eyePoint);

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -50,7 +50,7 @@ define([
                 WorldWind.configuration.baseUrl + 'images/dnb_land_ocean_ice_2012.png';
 
             //Internal use only.
-            //The light direction in cartesian space, computed form the lightLocation or defaults to the eyePoint.
+            //The light direction in cartesian space, computed from the layer time or defaults to the eyePoint.
             this._activeLightDirection = new Vec3(0, 0, 0);
 
             this._fullSphereSector = Sector.FULL_SPHERE;

--- a/src/layer/AtmosphereLayer.js
+++ b/src/layer/AtmosphereLayer.js
@@ -14,6 +14,7 @@ define([
         '../geom/Matrix3',
         '../geom/Sector',
         '../shaders/SkyProgram',
+        '../util/SunPosition',
         '../geom/Vec3',
         '../util/WWUtil'
     ],
@@ -25,6 +26,7 @@ define([
               Matrix3,
               Sector,
               SkyProgram,
+              SunPosition,
               Vec3,
               WWUtil) {
         "use strict";
@@ -80,7 +82,8 @@ define([
         Object.defineProperties(AtmosphereLayer.prototype, {
 
             /**
-             * The geographic location of the light (sun).
+             * The geographic location of the light (sun). If the Layer time property is set, this location will be
+             * overriden to reflect the location of the sun at the specified time.
              * @memberof AtmosphereLayer.prototype
              * @type {Position}
              */
@@ -319,11 +322,14 @@ define([
 
         // Internal. Intentionally not documented.
         AtmosphereLayer.prototype.determineLightDirection = function (dc) {
-            if (this.lightLocation != null) {
+            if (this.time !== null) {
+                this.lightLocation = SunPosition.getAsGeographicLocation(this.time);
+            }
+
+            if (this.lightLocation) {
                 dc.globe.computePointFromLocation(this.lightLocation.latitude, this.lightLocation.longitude,
                     this._activeLightDirection);
-            }
-            else {
+            } else {
                 this._activeLightDirection.copy(dc.navigatorState.eyePoint);
             }
             this._activeLightDirection.normalize();


### PR DESCRIPTION
Closes #100 

This pull request removes the `lightLocation` property and uses the layer time property (if not null) to determine the sun location in the Atmosphere layer.