### PR TITLE
Publish API documentation to gh-pages on every push to develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,13 @@ script:
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:
+  # Publish API documentation to GitHub Pages
+  - provider: pages
+    github_token: $GITHUB_API_KEY
+    local_dir: dist/api-doc
+    skip_cleanup: true
+    on:
+      branch: develop
   # Publish release artifacts to the npm repository
   - provider: npm
     email: $NPM_EMAIL


### PR DESCRIPTION
### Description of the Change

Publish the WebWorldWind API documentation to the built-in GitHub pages site after every push to develop. The resultant documentation is immediately available online and always up-to-date. The WorldWind website links to this documentation from the Android documentation page.

https://NASAWorldWind.github.io/WebWorldWind

### Why Should This Be In Core?

See description.

### Benefits

See description.

### Potential Drawbacks

None.

### Applicable Issues

Closes #286  