### PR TITLE
Publish dist archive contents to Artifactory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,11 @@ deploy:
     on:
       tags: true
   # Publish the contents of the dist archive to Artifactory for develop branch updates
-    - provider: script
-      script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/latest
-      skip_cleanup: true
-      on:
-        branch: develop
+  - provider: script
+    script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/latest
+    skip_cleanup: true
+    on:
+      branch: develop
   # Create CHANGELOG.md in the current directory
   - provider: script
     script: ./travis/changelog.sh >> CHANGELOG.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,12 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
+  # Publish the contents of the dist archive to Artifactory for develop branch updates
+    - provider: script
+      script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/latest
+      skip_cleanup: true
+      on:
+        branch: develop
   # Create CHANGELOG.md in the current directory
   - provider: script
     script: ./travis/changelog.sh >> CHANGELOG.md

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,12 @@ script:
 
 # Deploy build artifacts. Travis does not invoke this step for pull request builds
 deploy:
+  # Publish the contents of the dist archive to Artifactory instance at Ames
+  - provider: script
+    script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/apps/web
+    skip_cleanup: true
+    on:
+      branch: develop
   # Publish API documentation to GitHub Pages
   - provider: pages
     github_token: $GITHUB_API_KEY
@@ -34,12 +40,6 @@ deploy:
     skip_cleanup: true
     on:
       tags: true
-  # Publish the contents of the dist archive to Artifactory for develop branch updates
-  - provider: script
-    script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/latest
-    skip_cleanup: true
-    on:
-      branch: develop
   # Create CHANGELOG.md in the current directory
   - provider: script
     script: ./travis/changelog.sh >> CHANGELOG.md


### PR DESCRIPTION
### Description of the Change

A task was added to the continuous integration process to publish the contents of the `build/dist` folder to Artifactory under the path `artifactory/apps/web`. The task is executed on every update of the develop branch.

### Why Should This Be In Core?

This change will provide the public with updated examples which reflect the current state of the develop branch. The automation reduces overhead of maintaining the examples.

### Applicable Issues

Closes #285 