### PR TITLE
Configured WebStorm project's test sources folder

### DIFF
--- a/.idea/WebWorldWind.iml
+++ b/.idea/WebWorldWind.iml
@@ -2,6 +2,7 @@
 <module type="WEB_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/test" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludePattern pattern="nasaworldwind-worldwind-*.tgz" />
       <excludePattern pattern="npm-debug.log" />


### PR DESCRIPTION
### Description of the Change

Configures the repository's test folder as the WebStorm project's test root.

### Why Should This Be In Core?

Common WebStorm project configuration.

### Benefits

Enables WebStorm searches to categorize results as source and test, reducing search result clutter from unit test code.

### Potential Drawbacks

None.

### Applicable Issues

None.