### PR TITLE
Removed obsolete Subversion @version keywords from all files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Gruntfile.js 3107 2015-05-26 18:22:54Z tgaskins $
- */
 module.exports = function (grunt) {
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),

--- a/apps/Explorer.html
+++ b/apps/Explorer.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-<!--@version $Id: Explorer.html 3362 2015-07-31 19:29:12Z tgaskins $-->
 <head>
     <meta charset="utf-8">
     <title>Explorer</title>

--- a/apps/Explorer/Explorer.css
+++ b/apps/Explorer/Explorer.css
@@ -1,4 +1,3 @@
-/* @version $Id: Explorer.css 3296 2015-06-30 20:19:26Z tgaskins $ */
 .wrap-panel-heading {
     white-space: normal;
     -ms-word-wrap: break-word;

--- a/apps/Explorer/Explorer.js
+++ b/apps/Explorer/Explorer.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Explorer.js 3362 2015-07-31 19:29:12Z tgaskins $
- */
 define(['../../src/WorldWind',
         '../util/GoToBox',
         '../util/LayersPanel',

--- a/apps/Explorer/app.js
+++ b/apps/Explorer/app.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: app.js 3185 2015-06-12 19:12:09Z tgaskins $
- */
-
 requirejs.config({
     "paths": {
         "Explorer": "Explorer"

--- a/apps/NEO/DatasetDropdown.js
+++ b/apps/NEO/DatasetDropdown.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: DatasetDropdown.js 3411 2015-08-17 04:23:28Z tgaskins $
- */
 define(function () {
     "use strict";
 

--- a/apps/NEO/LayerDropdown.js
+++ b/apps/NEO/LayerDropdown.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: LayerDropdown.js 3411 2015-08-17 04:23:28Z tgaskins $
- */
 define(function () {
     "use strict";
 

--- a/apps/NEO/NEO.js
+++ b/apps/NEO/NEO.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: NEO.js 3411 2015-08-17 04:23:28Z tgaskins $
- */
 define(['../../src/WorldWind',
         './DatasetDropdown',
         './LayerDropdown',

--- a/apps/NEO/app.js
+++ b/apps/NEO/app.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: app.js 3411 2015-08-17 04:23:28Z tgaskins $
- */
-
 requirejs.config({
     "paths": {
         "NEO": "NEO"

--- a/apps/SubSurface.html
+++ b/apps/SubSurface.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-<!--@version $Id: SubSurface.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <head>
     <meta charset="utf-8">
     <title>WorldWind Subsurface</title>

--- a/apps/SubSurface/SubSurface.js
+++ b/apps/SubSurface/SubSurface.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: SubSurface.js 3320 2015-07-15 20:53:05Z dcollins $
- */
 define(['../../src/WorldWind',
         '../util/GoToBox',
         '../util/LayersPanel',

--- a/apps/SubSurface/app.js
+++ b/apps/SubSurface/app.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: app.js 3059 2015-05-04 21:11:01Z tgaskins $
- */
-
 requirejs.config({
     "paths": {
         "SubSurface": "SubSurface"

--- a/apps/USGSSlabs.html
+++ b/apps/USGSSlabs.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html lang="en">
-<!--@version $Id: USGSSlabs.html 3322 2015-07-17 00:17:31Z tgaskins $-->
 <head>
     <meta charset="utf-8">
     <title>WorldWind USGS Slabs</title>

--- a/apps/USGSSlabs/USGSSlabs.js
+++ b/apps/USGSSlabs/USGSSlabs.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: USGSSlabs.js$
- */
 define(['../../src/WorldWind',
         '../util/GoToBox',
         '../util/LayersPanel',

--- a/apps/USGSSlabs/app.js
+++ b/apps/USGSSlabs/app.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: app.js$
- */
-
 requirejs.config({
     "paths": {
         "USGSSlabs": "USGSSlabs"

--- a/apps/util/GoToBox.js
+++ b/apps/util/GoToBox.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GoToBox
- * @version $Id: GoToBox.js 3185 2015-06-12 19:12:09Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/apps/util/LayersPanel.js
+++ b/apps/util/LayersPanel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports LayersPanel
- * @version $Id: LayersPanel.js 3362 2015-07-31 19:29:12Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/apps/util/ProjectionMenu.js
+++ b/apps/util/ProjectionMenu.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ProjectionMenu
- * @version $Id: ProjectionMenu.js 3185 2015-06-12 19:12:09Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/apps/util/ServersPanel.js
+++ b/apps/util/ServersPanel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ServersPanel
- * @version $Id: ServersPanel.js 3413 2015-08-20 19:08:20Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/apps/util/TerrainOpacityController.js
+++ b/apps/util/TerrainOpacityController.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TerrainOpacityController
- * @version $Id: TerrainOpacityController.js 3217 2015-06-19 18:58:03Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/apps/util/TimeSeriesPlayer.js
+++ b/apps/util/TimeSeriesPlayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TimeSeriesPlayer
- * @version $Id: TimeSeriesPlayer.js 3410 2015-08-17 04:23:05Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/examples/Atmosphere.html
+++ b/examples/Atmosphere.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Shapefiles.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/BasicExample.html
+++ b/examples/BasicExample.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: BasicExample.html 3314 2015-07-10 18:28:45Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/BasicExample.js
+++ b/examples/BasicExample.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: BasicExample.js 3320 2015-07-15 20:53:05Z dcollins $
- */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/BlueMarbleTimeSeries.html
+++ b/examples/BlueMarbleTimeSeries.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: BlueMarbleTimeSeries.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Configuration.html
+++ b/examples/Configuration.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Configuration.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Configuration.js
+++ b/examples/Configuration.js
@@ -5,10 +5,7 @@
 /**
  * Illustrates the WorldWind configuration options and how to set them. In order to have an effect, most configuration
  * options must be set before creating a WorldWindow or any other WorldWind object.
- *
- * @version $Id: Configuration.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/CoordinateController.css
+++ b/examples/CoordinateController.css
@@ -1,5 +1,3 @@
-/* @version $Id: CoordinateController.css 3117 2015-05-27 19:36:35Z dcollins $ */
-
 /* Coordinate overlay common attributes. */
 #coordinateOverlay {
     color: yellow;

--- a/examples/CoordinateController.js
+++ b/examples/CoordinateController.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports CoordinateController
- * @version $Id: CoordinateController.js 3313 2015-07-10 17:59:29Z dcollins $
  */
 define(function () {
     "use strict";

--- a/examples/CustomPlacemark.html
+++ b/examples/CustomPlacemark.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: CustomPlacemark.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/CustomPlacemark.js
+++ b/examples/CustomPlacemark.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to create a placemark with a dynamically created image.
- *
- * @version $Id: CustomPlacemark.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/DeepPIcking.html
+++ b/examples/DeepPIcking.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: DeepPicking.html 3103 2015-05-20 00:27:44Z tgaskins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/DeepPicking.js
+++ b/examples/DeepPicking.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to set up deep picking. See line 117.
- *
- * @version $Id: DeepPicking.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/DigitalGlobe.html
+++ b/examples/DigitalGlobe.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: DigitalGlobe.html 3418 2015-08-22 00:17:05Z tgaskins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/DigitalGlobe.js
+++ b/examples/DigitalGlobe.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: DigitalGlobe.js 3418 2015-08-22 00:17:05Z tgaskins $
- */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/GeoJSON.html
+++ b/examples/GeoJSON.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Shapefiles.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/GeoTiffExample.html
+++ b/examples/GeoTiffExample.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Shapefiles.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/GeographicMeshes.html
+++ b/examples/GeographicMeshes.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: GeographicMeshes.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/GeographicMeshes.js
+++ b/examples/GeographicMeshes.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display GeographicMesh shapes.
- *
- * @version $Id: GeographicMeshes.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/GeographicText.html
+++ b/examples/GeographicText.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: GeographicText.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/GeographicText.js
+++ b/examples/GeographicText.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display text at geographic positions.
- *
- * @version $Id: GeographicText.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/GoToLocation.html
+++ b/examples/GoToLocation.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: GoToLocation.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/GoToLocation.js
+++ b/examples/GoToLocation.js
@@ -5,10 +5,7 @@
 /**
  * Illustrates how to use a GoToAnimator to smoothly move the view to a new location. This example listens for
  * terrain picks and moves the view to the location picked.
- *
- * @version $Id: GoToLocation.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/KmlExample.html
+++ b/examples/KmlExample.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Polygons.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/MultiWindow.html
+++ b/examples/MultiWindow.html
@@ -1,4 +1,3 @@
-<!--@version $Id: MultiWindow.html 3103 2015-05-20 00:27:44Z tgaskins $-->
 <!DOCTYPE html>
 <html>
 <head lang="en">

--- a/examples/MultiWindow.js
+++ b/examples/MultiWindow.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates the use of multiple WorldWindows on the same page.
- *
- * @version $Id: MultiWindow.js 3314 2015-07-10 18:28:45Z dcollins $
  */
-
 requirejs(['./WorldWindShim'], function () {
     "use strict";
 

--- a/examples/NDVIViewer.html
+++ b/examples/NDVIViewer.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: GeographicMeshes.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/ParseUrlArguments.html
+++ b/examples/ParseUrlArguments.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: ParseUrlArguments.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/ParseUrlArguments.js
+++ b/examples/ParseUrlArguments.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: ParseUrlArguments.js 3320 2015-07-15 20:53:05Z dcollins $
- */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/Paths.html
+++ b/examples/Paths.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Paths.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Paths.js
+++ b/examples/Paths.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick Paths.
- *
- * @version $Id: Paths.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/PickAllShapesInRegion.html
+++ b/examples/PickAllShapesInRegion.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: PickAllShapesInRegion.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/PickAllShapesInRegion.js
+++ b/examples/PickAllShapesInRegion.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: PickAllShapesInRegion.js 3320 2015-07-15 20:53:05Z dcollins $
- */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/PlacemarksAndPicking.html
+++ b/examples/PlacemarksAndPicking.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: PlacemarksAndPicking.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/PlacemarksAndPicking.js
+++ b/examples/PlacemarksAndPicking.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick Placemarks.
- *
- * @version $Id: PlacemarksAndPicking.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/Polygons.html
+++ b/examples/Polygons.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Polygons.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Polygons.js
+++ b/examples/Polygons.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick Polygons.
- *
- * @version $Id: Polygons.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/RefreshImagery.html
+++ b/examples/RefreshImagery.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: RefreshImagery.html 3103 2015-05-20 00:27:44Z tgaskins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/RefreshImagery.js
+++ b/examples/RefreshImagery.js
@@ -5,10 +5,7 @@
 /**
  * Shows how to cause an image layer's imagery to be re-retrieved from its origin. You should do this only if you
  * know the imagery is changing at the server.
- *
- * @version $Id: RefreshImagery.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/ScreenImage.html
+++ b/examples/ScreenImage.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: ScreenImage.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/ScreenImage.js
+++ b/examples/ScreenImage.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick ScreenImages.
- *
- * @version $Id: ScreenImage.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/ScreenText.html
+++ b/examples/ScreenText.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: ScreenText.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display text at screen positions. Uses offsets to align the text relative to its position.
- *
- * @version $Id: ScreenText.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/Shapefiles.html
+++ b/examples/Shapefiles.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Shapefiles.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Shapefiles.js
+++ b/examples/Shapefiles.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Shapefiles.js 3361 2015-07-31 19:28:04Z tgaskins $
- */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/SurfaceImage.html
+++ b/examples/SurfaceImage.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: SurfaceImage.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/SurfaceImage.js
+++ b/examples/SurfaceImage.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick SurfaceImages.
- *
- * @version $Id: SurfaceImage.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/SurfaceShapes.html
+++ b/examples/SurfaceShapes.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: SurfaceShapes.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/SurfaceShapes.js
+++ b/examples/SurfaceShapes.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display SurfaceShapes.
- *
- * @version $Id: SurfaceShapes.js 3320 2015-07-15 20:53:05Z dcollins $
  */
-
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind,

--- a/examples/TestMovingSurfaceShapes.html
+++ b/examples/TestMovingSurfaceShapes.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: BasicExample.html 3314 2015-07-10 18:28:45Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/WMTS.html
+++ b/examples/WMTS.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: WMTS.html 3320 2016-07-12 11:10 rsirac $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/examples/Wkt.html
+++ b/examples/Wkt.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Wkt.html 3320 2017-02-16 17:32:00Z jveselka $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web World Wind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/performance/DeepPickingPerformance.html
+++ b/performance/DeepPickingPerformance.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: SurfaceShapes.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/performance/ShapefilesComplex.html
+++ b/performance/ShapefilesComplex.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: Shapefiles.html 3320 2015-07-15 20:53:05Z dcollins $-->
 <html lang="en">
 <head>
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->

--- a/performance/ShapefilesComplex.js
+++ b/performance/ShapefilesComplex.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: ShapefilesComplex.js 3102 2015-05-20 00:20:02Z tgaskins $
- */
-
 requirejs(['../src/WorldWind',
         '../examples/LayerManager',
         '../examples/CoordinateController'],

--- a/performance/SurfaceShapesComplex.js
+++ b/performance/SurfaceShapesComplex.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display SurfaceShapes.
- *
- * @version $Id: SurfaceShapes.js 3189 2015-06-15 19:27:19Z tgaskins $
  */
-
 requirejs(['../src/WorldWind',
         '../examples/LayerManager',
         '../examples/CoordinateController'],

--- a/performance/VeryManyPaths.html
+++ b/performance/VeryManyPaths.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: VeryManyPaths.html 3062 2015-05-05 18:31:25Z tgaskins $-->
 <html lang="en">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/performance/VeryManyPaths.js
+++ b/performance/VeryManyPaths.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick Paths.
- *
- * @version $Id: VeryManyPaths.js 3259 2015-06-25 00:53:55Z tgaskins $
  */
-
 requirejs(['../src/WorldWind',
         '../examples/LayerManager'],
     function (ww,

--- a/performance/VeryManyPolygons.html
+++ b/performance/VeryManyPolygons.html
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<!--@version $Id: VeryManyPolygons.html 3062 2015-05-05 18:31:25Z tgaskins $-->
 <html lang="en">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/performance/VeryManyPolygons.js
+++ b/performance/VeryManyPolygons.js
@@ -4,10 +4,7 @@
  */
 /**
  * Illustrates how to display and pick Paths.
- *
- * @version $Id: VeryManyPolygons.js 3259 2015-06-25 00:53:55Z tgaskins $
  */
-
 requirejs(['../src/WorldWind',
         '../examples/LayerManager'],
     function (ww,

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: WorldWind.js 3418 2015-08-22 00:17:05Z tgaskins $
- */
 define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not directory name).
         './error/AbstractError',
         './geom/Angle',

--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WorldWindow
- * @version $Id: WorldWindow.js 3402 2015-08-14 17:28:09Z tgaskins $
  */
 define([
         './error/ArgumentError',

--- a/src/cache/GpuResourceCache.js
+++ b/src/cache/GpuResourceCache.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GpuResourceCache
- * @version $Id: GpuResourceCache.js 3023 2015-04-15 20:24:17Z tgaskins $
  */
 define([
         '../util/AbsentResourceList',

--- a/src/cache/MemoryCache.js
+++ b/src/cache/MemoryCache.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports MemoryCache
- * @version $Id: MemoryCache.js 2911 2015-03-19 18:36:01Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/cache/MemoryCacheListener.js
+++ b/src/cache/MemoryCacheListener.js
@@ -3,11 +3,8 @@
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
 /**
- * @exports MemoryCacheListener
- * @version $Id: MemoryCacheListener.js 2912 2015-03-19 18:49:29Z tgaskins $
- */
-/**
  * Defines an interface for {@link MemoryCache} listeners.
+ * @exports MemoryCacheListener
  * @interface MemoryCacheListener
  */
 define([

--- a/src/error/AbstractError.js
+++ b/src/error/AbstractError.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports AbstractError
- * @version $Id: AbstractError.js 2913 2015-03-19 19:01:18Z tgaskins $
  */
 define(function () {
     "use strict";

--- a/src/error/ArgumentError.js
+++ b/src/error/ArgumentError.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ArgumentError
- * @version $Id: ArgumentError.js 2631 2015-01-02 21:32:32Z tgaskins $
  */
 define(['../error/AbstractError'],
     function (AbstractError) {

--- a/src/error/NotYetImplementedError.js
+++ b/src/error/NotYetImplementedError.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports NotYetImplementedError
- * @version $Id: NotYetImplementedError.js 2631 2015-01-02 21:32:32Z tgaskins $
  */
 define(['../error/AbstractError'],
     function (AbstractError) {

--- a/src/error/UnsupportedOperationError.js
+++ b/src/error/UnsupportedOperationError.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports UnsupportedOperationError
- * @version $Id: UnsupportedOperationError.js 2631 2015-01-02 21:32:32Z tgaskins $
  */
 define(['../error/AbstractError'],
     function (AbstractError) {

--- a/src/formats/shapefile/DBaseField.js
+++ b/src/formats/shapefile/DBaseField.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DBaseField
- * @version $Id: DBaseField.js 2974 2015-04-03 19:52:11Z tgaskins $
  */
 define(['../../error/ArgumentError',
         '../../util/ByteBuffer',

--- a/src/formats/shapefile/DBaseFile.js
+++ b/src/formats/shapefile/DBaseFile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DBaseFile
- * @version $Id: DBaseFile.js 2985 2015-04-06 23:23:35Z danm $
  */
 define(['../../error/ArgumentError',
         '../../util/ByteBuffer',

--- a/src/formats/shapefile/DBaseRecord.js
+++ b/src/formats/shapefile/DBaseRecord.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DBaseRecord
- * @version $Id: DBaseRecord.js 2980 2015-04-03 23:45:43Z danm $
  */
 define(['../../error/ArgumentError',
         '../../util/ByteBuffer',

--- a/src/formats/shapefile/PrjFile.js
+++ b/src/formats/shapefile/PrjFile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PrjFile
- * @version $Id: PrjFile.js 2960 2015-04-02 01:17:06Z danm $
  */
 define(['../../error/ArgumentError',
         '../../util/Logger',

--- a/src/formats/shapefile/Shapefile.js
+++ b/src/formats/shapefile/Shapefile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Shapefile
- * @version $Id: Shapefile.js 3259 2015-06-25 00:53:55Z tgaskins $
  */
 define([
         '../../geom/Angle',

--- a/src/formats/shapefile/ShapefileRecord.js
+++ b/src/formats/shapefile/ShapefileRecord.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecord
- * @version $Id: ShapefileRecord.js 3190 2015-06-15 19:30:14Z tgaskins $
  */
 define([
         '../../geom/Angle',

--- a/src/formats/shapefile/ShapefileRecordMultiPoint.js
+++ b/src/formats/shapefile/ShapefileRecordMultiPoint.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecordMultiPoint
- * @version $Id: ShapefileRecordMultiPoint.js 2984 2015-04-06 23:00:34Z danm $
  */
 define(['../../util/ByteBuffer',
         '../../formats/shapefile/Shapefile',

--- a/src/formats/shapefile/ShapefileRecordNull.js
+++ b/src/formats/shapefile/ShapefileRecordNull.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecordNull
- * @version $Id: ShapefileRecordNull.js 2984 2015-04-06 23:00:34Z danm $
  */
 define(['../../formats/shapefile/Shapefile',
         '../../formats/shapefile/ShapefileRecord'

--- a/src/formats/shapefile/ShapefileRecordPoint.js
+++ b/src/formats/shapefile/ShapefileRecordPoint.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecordPoint
- * @version $Id: ShapefileRecordPoint.js 2984 2015-04-06 23:00:34Z danm $
  */
 define(['../../formats/shapefile/Shapefile',
         '../../formats/shapefile/ShapefileRecord'

--- a/src/formats/shapefile/ShapefileRecordPolygon.js
+++ b/src/formats/shapefile/ShapefileRecordPolygon.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecordPolygon
- * @version $Id: ShapefileRecordPolygon.js 2984 2015-04-06 23:00:34Z danm $
  */
 define(['../../formats/shapefile/Shapefile',
         '../../formats/shapefile/ShapefileRecord'

--- a/src/formats/shapefile/ShapefileRecordPolyline.js
+++ b/src/formats/shapefile/ShapefileRecordPolyline.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapefileRecordPolyline
- * @version $Id: ShapefileRecordPolyline.js 2984 2015-04-06 23:00:34Z danm $
  */
 define(['../../formats/shapefile/Shapefile',
         '../../formats/shapefile/ShapefileRecord'

--- a/src/geom/Angle.js
+++ b/src/geom/Angle.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Angle.js 2914 2015-03-19 19:10:19Z tgaskins $
- */
 define([], function () {
     "use strict";
     /**

--- a/src/geom/BoundingBox.js
+++ b/src/geom/BoundingBox.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BoundingBox
- * @version $Id: BoundingBox.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/geom/Frustum.js
+++ b/src/geom/Frustum.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Frustum
- * @version $Id: Frustum.js 2919 2015-03-22 20:46:59Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/geom/Line.js
+++ b/src/geom/Line.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Line
- * @version $Id: Line.js 2935 2015-03-27 17:59:48Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/geom/Location.js
+++ b/src/geom/Location.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Location
- * @version $Id: Location.js 3116 2015-05-27 01:30:07Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/geom/Matrix.js
+++ b/src/geom/Matrix.js
@@ -4,9 +4,7 @@
  */
 /**
  * @exports Matrix
- * @version $Id: Matrix.js 3298 2015-07-06 17:28:33Z dcollins $
  */
-
 define([
         '../geom/Angle',
         '../error/ArgumentError',

--- a/src/geom/Plane.js
+++ b/src/geom/Plane.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Plane
- * @version $Id: Plane.js 2935 2015-03-27 17:59:48Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/geom/Position.js
+++ b/src/geom/Position.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Position
- * @version $Id: Position.js 2933 2015-03-27 01:18:24Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/geom/Rectangle.js
+++ b/src/geom/Rectangle.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Rectangle
- * @version $Id: Rectangle.js 3174 2015-06-10 19:36:49Z tgaskins $
  */
 define([
         '../util/Logger'

--- a/src/geom/Sector.js
+++ b/src/geom/Sector.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Sector
- * @version $Id: Sector.js 2933 2015-03-27 01:18:24Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/geom/Vec2.js
+++ b/src/geom/Vec2.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Vec2.js 2946 2015-03-31 20:37:33Z dcollins $
- */
-
 define([
         '../util/Logger',
         '../error/ArgumentError',

--- a/src/geom/Vec3.js
+++ b/src/geom/Vec3.js
@@ -2,10 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Vec3.js 3001 2015-04-09 20:13:50Z tgaskins $
- */
-
 define([
         '../util/Logger',
         '../error/ArgumentError'

--- a/src/gesture/ClickRecognizer.js
+++ b/src/gesture/ClickRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ClickRecognizer
- * @version $Id: ClickRecognizer.js 3223 2015-06-19 23:16:36Z dcollins $
  */
 define(['../gesture/GestureRecognizer'],
     function (GestureRecognizer) {

--- a/src/gesture/DragRecognizer.js
+++ b/src/gesture/DragRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DragRecognizer
- * @version $Id: DragRecognizer.js 3223 2015-06-19 23:16:36Z dcollins $
  */
 define(['../gesture/GestureRecognizer'],
     function (GestureRecognizer) {

--- a/src/gesture/GestureRecognizer.js
+++ b/src/gesture/GestureRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GestureRecognizer
- * @version $Id: GestureRecognizer.js 3241 2015-06-22 23:52:49Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/gesture/PanRecognizer.js
+++ b/src/gesture/PanRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PanRecognizer
- * @version $Id: PanRecognizer.js 3239 2015-06-22 23:28:12Z dcollins $
  */
 define(['../gesture/GestureRecognizer'],
     function (GestureRecognizer) {

--- a/src/gesture/PinchRecognizer.js
+++ b/src/gesture/PinchRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PinchRecognizer
- * @version $Id: PinchRecognizer.js 3239 2015-06-22 23:28:12Z dcollins $
  */
 define(['../gesture/GestureRecognizer'],
     function (GestureRecognizer) {

--- a/src/gesture/RotationRecognizer.js
+++ b/src/gesture/RotationRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports RotationRecognizer
- * @version $Id: RotationRecognizer.js 3239 2015-06-22 23:28:12Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/gesture/TapRecognizer.js
+++ b/src/gesture/TapRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TapRecognizer
- * @version $Id: TapRecognizer.js 3223 2015-06-19 23:16:36Z dcollins $
  */
 define(['../gesture/GestureRecognizer'],
     function (GestureRecognizer) {

--- a/src/gesture/TiltRecognizer.js
+++ b/src/gesture/TiltRecognizer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TiltRecognizer
- * @version $Id: TiltRecognizer.js 3223 2015-06-19 23:16:36Z dcollins $
  */
 define(['../gesture/PanRecognizer'],
     function (PanRecognizer) {

--- a/src/gesture/Touch.js
+++ b/src/gesture/Touch.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Touch
- * @version $Id: Touch.js 3221 2015-06-19 22:55:04Z dcollins $
  */
 define([],
     function () {

--- a/src/globe/EarthElevationModel.js
+++ b/src/globe/EarthElevationModel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports EarthElevationModel
- * @version $Id: EarthElevationModel.js 2936 2015-03-27 22:04:59Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/globe/EarthRestElevationModel.js
+++ b/src/globe/EarthRestElevationModel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports EarthRestElevationModel
- * @version $Id: EarthElevationModel.js 2638 2015-01-05 20:44:18Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/globe/ElevationImage.js
+++ b/src/globe/ElevationImage.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ElevationImage
- * @version $Id: ElevationImage.js 2936 2015-03-27 22:04:59Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/globe/ElevationModel.js
+++ b/src/globe/ElevationModel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ElevationModel
- * @version $Id: ElevationModel.js 3415 2015-08-20 19:15:57Z tgaskins $
  */
 define([
         '../util/AbsentResourceList',

--- a/src/globe/ElevationTile.js
+++ b/src/globe/ElevationTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ElevationTile
- * @version $Id: ElevationTile.js 2936 2015-03-27 22:04:59Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/globe/Globe.js
+++ b/src/globe/Globe.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Globe
- * @version $Id: Globe.js 2940 2015-03-30 17:58:36Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/globe/Globe2D.js
+++ b/src/globe/Globe2D.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Globe2D
- * @version $Id: Globe2D.js 3205 2015-06-17 18:05:23Z tgaskins $
  */
 define([
         '../globe/Globe',

--- a/src/globe/Terrain.js
+++ b/src/globe/Terrain.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Terrain
- * @version $Id: Terrain.js 3018 2015-04-14 17:50:06Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/globe/TerrainTile.js
+++ b/src/globe/TerrainTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TerrainTile
- * @version $Id: TerrainTile.js 2936 2015-03-27 22:04:59Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/globe/TerrainTileList.js
+++ b/src/globe/TerrainTileList.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TerrainTileList
- * @version $Id: TerrainTileList.js 2758 2015-02-09 00:20:46Z tgaskins $
  */
 define(['../error/ArgumentError',
         '../util/Logger',

--- a/src/globe/Tessellator.js
+++ b/src/globe/Tessellator.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Tessellator
- * @version $Id: Tessellator.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/globe/ZeroElevationModel.js
+++ b/src/globe/ZeroElevationModel.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ZeroElevationModel
- * @version $Id: ZeroElevationModel.js 2936 2015-03-27 22:04:59Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/BMNGLandsatLayer.js
+++ b/src/layer/BMNGLandsatLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BMNGLandsatLayer
- * @version $Id: BMNGLandsatLayer.js 3403 2015-08-15 02:00:01Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/BMNGLayer.js
+++ b/src/layer/BMNGLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BMNGLayer
- * @version $Id: BMNGLayer.js 3403 2015-08-15 02:00:01Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/BMNGOneImageLayer.js
+++ b/src/layer/BMNGOneImageLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BMNGOneImageLayer
- * @version $Id: BMNGOneImageLayer.js 2942 2015-03-30 21:16:36Z tgaskins $
  */
 define([
         '../layer/RenderableLayer',

--- a/src/layer/BingAerialLayer.js
+++ b/src/layer/BingAerialLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingAerialLayer
- * @version $Id: BingAerialLayer.js 2883 2015-03-06 19:04:42Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/BingAerialWithLabelsLayer.js
+++ b/src/layer/BingAerialWithLabelsLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingAerialWithLabelsLayer
- * @version $Id: BingAerialWithLabelsLayer.js 2883 2015-03-06 19:04:42Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/BingRoadsLayer.js
+++ b/src/layer/BingRoadsLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingRoadsLayer
- * @version $Id: BingRoadsLayer.js 2883 2015-03-06 19:04:42Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingTiledImageLayer
- * @version $Id: BingTiledImageLayer.js 3120 2015-05-28 02:32:45Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/layer/BingWMSLayer.js
+++ b/src/layer/BingWMSLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingWMSLayer
- * @version $Id: BingWMSLayer.js 3403 2015-08-15 02:00:01Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/layer/CompassLayer.js
+++ b/src/layer/CompassLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports CompassLayer
- * @version $Id: CompassLayer.js 2978 2015-04-03 22:55:55Z tgaskins $
  */
 define([
         '../shapes/Compass',

--- a/src/layer/CoordinatesDisplayLayer.js
+++ b/src/layer/CoordinatesDisplayLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports CoordinatesDisplayLayer
- * @version $Id: CoordinatesDisplayLayer.js 3319 2015-07-15 20:45:54Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/DigitalGlobeTiledImageLayer.js
+++ b/src/layer/DigitalGlobeTiledImageLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DigitalGlobeTiledImageLayer
- * @version $Id: DigitalGlobeTiledImageLayer.js 3418 2015-08-22 00:17:05Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/layer/FrameStatisticsLayer.js
+++ b/src/layer/FrameStatisticsLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports FrameStatisticsLayer
- * @version $Id: FrameStatisticsLayer.js 3343 2015-07-28 18:22:59Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/LandsatRestLayer.js
+++ b/src/layer/LandsatRestLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports LandsatRestLayer
- * @version $Id: LandsatRestLayer.js 2939 2015-03-30 16:50:49Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Layer
- * @version $Id: Layer.js 3414 2015-08-20 19:09:19Z tgaskins $
  */
 define([
         '../util/Logger'

--- a/src/layer/MercatorTiledImageLayer.js
+++ b/src/layer/MercatorTiledImageLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports MercatorTiledImageLayer
- * @version $Id: MercatorTiledImageLayer.js 3120 2015-05-28 02:32:45Z tgaskins $
  */
 define([
         '../util/Color',

--- a/src/layer/OpenStreetMapImageLayer.js
+++ b/src/layer/OpenStreetMapImageLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports OpenStreetMapImageLayer
- * @version $Id: OpenStreetMapImageLayer.js 3120 2015-05-28 02:32:45Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/layer/RenderableLayer.js
+++ b/src/layer/RenderableLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports RenderableLayer
- * @version $Id: RenderableLayer.js 3334 2015-07-22 19:15:43Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/ShowTessellationLayer.js
+++ b/src/layer/ShowTessellationLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShowTessellationLayer
- * @version $Id: ShowTessellationLayer.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../shaders/BasicProgram',

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ViewControlsLayer
- * @version $Id: ViewControlsLayer.js 3142 2015-06-03 15:37:54Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/layer/WmsLayer.js
+++ b/src/layer/WmsLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WmsLayer
- * @version $Id: WmsLayer.js 3362 2015-07-31 19:29:12Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/layer/WmsTimeDimensionedLayer.js
+++ b/src/layer/WmsTimeDimensionedLayer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WmsTimeDimensionedLayer
- * @version $Id: WmsTimeDimensionedLayer.js 3362 2015-07-31 19:29:12Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/navigate/LookAtNavigator.js
+++ b/src/navigate/LookAtNavigator.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports LookAtNavigator
- * @version $Id: LookAtNavigator.js 3321 2015-07-16 21:34:58Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/navigate/Navigator.js
+++ b/src/navigate/Navigator.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Navigator
- * @version $Id: Navigator.js 3298 2015-07-06 17:28:33Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/navigate/NavigatorState.js
+++ b/src/navigate/NavigatorState.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports NavigatorState
- * @version $Id: NavigatorState.js 3279 2015-06-26 22:42:56Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/ogc/wms/WmsCapabilities.js
+++ b/src/ogc/wms/WmsCapabilities.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WmsCapabilities
- * @version $Id: WmsCapabilities.js 3055 2015-04-29 21:39:51Z tgaskins $
  */
 define([
         '../../error/ArgumentError',

--- a/src/ogc/wms/WmsLayerCapabilities.js
+++ b/src/ogc/wms/WmsLayerCapabilities.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WmsLayerCapabilities
- * @version $Id: WmsLayerCapabilities.js 3055 2015-04-29 21:39:51Z tgaskins $
  */
 define([
         '../../error/ArgumentError',

--- a/src/pick/PickedObject.js
+++ b/src/pick/PickedObject.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PickedObject
- * @version $Id: PickedObject.js 2940 2015-03-30 17:58:36Z tgaskins $
  */
 define([],
     function () {

--- a/src/pick/PickedObjectList.js
+++ b/src/pick/PickedObjectList.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PickedObjectList
- * @version $Id: PickedObjectList.js 2940 2015-03-30 17:58:36Z tgaskins $
  */
 define([],
     function () {

--- a/src/projections/GeographicProjection.js
+++ b/src/projections/GeographicProjection.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GeographicProjection
- * @version $Id: GeographicProjection.js 2821 2015-02-20 16:59:27Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/projections/ProjectionEquirectangular.js
+++ b/src/projections/ProjectionEquirectangular.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ProjectionEquirectangular
- * @version $Id: ProjectionEquirectangular.js 2821 2015-02-20 16:59:27Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/projections/ProjectionMercator.js
+++ b/src/projections/ProjectionMercator.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ProjectionMercator
- * @version $Id: ProjectionMercator.js 2821 2015-02-20 16:59:27Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/projections/ProjectionPolarEquidistant.js
+++ b/src/projections/ProjectionPolarEquidistant.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ProjectionPolarEquidistant
- * @version $Id: ProjectionPolarEquidistant.js 2821 2015-02-20 16:59:27Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/projections/ProjectionUPS.js
+++ b/src/projections/ProjectionUPS.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ProjectionUPS
- * @version $Id: ProjectionUPS.js 2821 2015-02-20 16:59:27Z dcollins $
  */
 define([
         '../geom/Angle',

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports DrawContext
- * @version $Id: DrawContext.js 3351 2015-07-28 22:03:20Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/FramebufferTexture.js
+++ b/src/render/FramebufferTexture.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports FramebufferTexture
- * @version $Id: FramebufferTexture.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/FramebufferTile.js
+++ b/src/render/FramebufferTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports FramebufferTile
- * @version $Id: FramebufferTile.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/FramebufferTileController.js
+++ b/src/render/FramebufferTileController.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports FramebufferTileController
- * @version $Id: FramebufferTileController.js 3130 2015-05-29 18:20:15Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/ImageTile.js
+++ b/src/render/ImageTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ImageTile
- * @version $Id: ImageTile.js 2941 2015-03-30 21:11:43Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/OrderedRenderable.js
+++ b/src/render/OrderedRenderable.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports OrderedRenderable
- * @version $Id: OrderedRenderable.js 2694 2015-01-28 02:19:33Z tgaskins $
  */
 define(['../util/Logger',
         '../error/UnsupportedOperationError'

--- a/src/render/Renderable.js
+++ b/src/render/Renderable.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Renderable
- * @version $Id: Renderable.js 2951 2015-03-31 23:31:08Z tgaskins $
  */
 define([
         '../util/Logger',

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ScreenCreditController
- * @version $Id: ScreenCreditController.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/SurfaceRenderable.js
+++ b/src/render/SurfaceRenderable.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceRenderable
- * @version $Id: SurfaceRenderable.js 3351 2015-07-28 22:03:20Z dcollins $
  */
 define(['../util/Logger',
         '../error/UnsupportedOperationError'

--- a/src/render/SurfaceTile.js
+++ b/src/render/SurfaceTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceTile
- * @version $Id: SurfaceTile.js 2941 2015-03-30 21:11:43Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/SurfaceTileRenderer.js
+++ b/src/render/SurfaceTileRenderer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceTileRenderer
- * @version $Id: SurfaceTileRenderer.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/TextSupport.js
+++ b/src/render/TextSupport.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TextSupport
- * @version $Id: TextSupport.js 3302 2015-07-06 22:20:36Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/Texture.js
+++ b/src/render/Texture.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Texture
- * @version $Id: Texture.js 3414 2015-08-20 19:09:19Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/render/TextureTile.js
+++ b/src/render/TextureTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TextureTile
- * @version $Id: TextureTile.js 2941 2015-03-30 21:11:43Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shaders/BasicProgram.js
+++ b/src/shaders/BasicProgram.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BasicProgram
- * @version $Id: BasicProgram.js 3327 2015-07-21 19:03:39Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shaders/BasicTextureProgram.js
+++ b/src/shaders/BasicTextureProgram.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BasicTextureProgram
- * @version $Id: BasicTextureProgram.js 3327 2015-07-21 19:03:39Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shaders/GpuProgram.js
+++ b/src/shaders/GpuProgram.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GpuProgram
- * @version $Id: GpuProgram.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shaders/GpuShader.js
+++ b/src/shaders/GpuShader.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GpuShader
- * @version $Id: GpuShader.js 2906 2015-03-17 18:45:22Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shaders/SurfaceTileRendererProgram.js
+++ b/src/shaders/SurfaceTileRendererProgram.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceTileRendererProgram
- * @version $Id: SurfaceTileRendererProgram.js 3327 2015-07-21 19:03:39Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/AbstractShape.js
+++ b/src/shapes/AbstractShape.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports AbstractShape
- * @version $Id: AbstractShape.js 3259 2015-06-25 00:53:55Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/Compass.js
+++ b/src/shapes/Compass.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Compass
- * @version $Id: Compass.js 3114 2015-05-27 01:08:58Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/GeographicText.js
+++ b/src/shapes/GeographicText.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GeographicText
- * @version $Id: GeographicText.js 3262 2015-06-25 16:50:39Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/Path.js
+++ b/src/shapes/Path.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Path
- * @version $Id: Path.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../shapes/AbstractShape',

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Placemark
- * @version $Id: Placemark.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/PlacemarkAttributes.js
+++ b/src/shapes/PlacemarkAttributes.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PlacemarkAttributes
- * @version $Id: PlacemarkAttributes.js 3023 2015-04-15 20:24:17Z tgaskins $
  */
 define([
         '../util/Color',

--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Polygon
- * @version $Id: Polygon.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../shapes/AbstractShape',

--- a/src/shapes/ScreenImage.js
+++ b/src/shapes/ScreenImage.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ScreenImage
- * @version $Id: ScreenImage.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/ScreenText.js
+++ b/src/shapes/ScreenText.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ScreenText
- * @version $Id: ScreenText.js 3293 2015-06-30 18:20:17Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/ShapeAttributes.js
+++ b/src/shapes/ShapeAttributes.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ShapeAttributes
- * @version $Id: ShapeAttributes.js 3270 2015-06-26 01:09:56Z tgaskins $
  */
 define([
         '../util/Color',

--- a/src/shapes/SurfaceCircle.js
+++ b/src/shapes/SurfaceCircle.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceCircle
- * @version $Id: SurfaceCircle.js 3014 2015-04-14 01:06:17Z danm $
  */
 define(['../error/ArgumentError',
         '../geom/Location',

--- a/src/shapes/SurfaceEllipse.js
+++ b/src/shapes/SurfaceEllipse.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceEllipse
- * @version $Id: SurfaceEllipse.js 3014 2015-04-14 01:06:17Z danm $
  */
 define([
         '../geom/Angle',

--- a/src/shapes/SurfaceImage.js
+++ b/src/shapes/SurfaceImage.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceImage
- * @version $Id: SurfaceImage.js 3023 2015-04-15 20:24:17Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/SurfacePolygon.js
+++ b/src/shapes/SurfacePolygon.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfacePolygon
- * @version $Id: SurfacePolygon.js 3193 2015-06-15 22:29:13Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/SurfacePolyline.js
+++ b/src/shapes/SurfacePolyline.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfacePolyline
- * @version $Id: SurfacePolyline.js 3014 2015-04-14 01:06:17Z danm $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/SurfaceRectangle.js
+++ b/src/shapes/SurfaceRectangle.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceRectangle
- * @version $Id: SurfaceRectangle.js 3195 2015-06-15 23:59:30Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/shapes/SurfaceSector.js
+++ b/src/shapes/SurfaceSector.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceSector
- * @version $Id: SurfaceSector.js 3014 2015-04-14 01:06:17Z danm $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/SurfaceShape.js
+++ b/src/shapes/SurfaceShape.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceShape
- * @version $Id: SurfaceShape.js 3191 2015-06-15 19:35:57Z tgaskins $
  */
 define([
         '../error/AbstractError',

--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceShapeTile
- * @version $Id: SurfaceShapeTile.js 3048 2015-04-23 23:26:47Z danm $
  */
 define([
         '../geom/Angle',

--- a/src/shapes/SurfaceShapeTileBuilder.js
+++ b/src/shapes/SurfaceShapeTileBuilder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports SurfaceShapeTileBuilder
- * @version $Id: SurfaceShapeTileBuilder.js 3048 2015-04-23 23:26:47Z danm $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Text
- * @version $Id: Text.js 3345 2015-07-28 20:28:35Z dcollins $
  */
 define([
         '../error/ArgumentError',

--- a/src/shapes/TextAttributes.js
+++ b/src/shapes/TextAttributes.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TextAttributes
- * @version $Id: TextAttributes.js 3295 2015-06-30 19:16:37Z tgaskins $
  */
 define([
         '../util/Color',

--- a/src/util/AbsentResourceList.js
+++ b/src/util/AbsentResourceList.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports AbsentResourceList
- * @version $Id: AbsentResourceList.js 2952 2015-04-01 00:33:54Z tgaskins $
  */
 define([],
     function () {

--- a/src/util/BingImageryUrlBuilder.js
+++ b/src/util/BingImageryUrlBuilder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports BingImageryUrlBuilder
- * @version $Id: BingImageryUrlBuilder.js 3094 2015-05-14 23:02:03Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/ByteBuffer.js
+++ b/src/util/ByteBuffer.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ByteBuffer
- * @version $Id: ByteBuffer.js 2954 2015-04-01 22:08:16Z danm $
  */
 define(['../error/ArgumentError',
         '../util/Logger'

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Color
- * @version $Id: Color.js 3017 2015-04-14 17:10:31Z dcollins $
  */
 define([
         '../util/Logger'

--- a/src/util/Font.js
+++ b/src/util/Font.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Font
- * @version $Id: Font.js 2660 2015-01-20 19:20:11Z danm $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/FrameStatistics.js
+++ b/src/util/FrameStatistics.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports FrameStatistics
- * @version $Id: FrameStatistics.js 3343 2015-07-28 18:22:59Z dcollins $
  */
 define([],
     function () {

--- a/src/util/GoToAnimator.js
+++ b/src/util/GoToAnimator.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports GoToAnimator
- * @version $Id: GoToAnimator.js 3164 2015-06-09 15:35:14Z tgaskins $
  */
 define([
         '../geom/Location',

--- a/src/util/HighlightController.js
+++ b/src/util/HighlightController.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports HighlightController
- * @version $Id: HighlightController.js 3260 2015-06-25 01:06:21Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/ImageSource.js
+++ b/src/util/ImageSource.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports ImageSource
- * @version $Id: ImageSource.js 3023 2015-04-15 20:24:17Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/Level.js
+++ b/src/util/Level.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Level
- * @version $Id: Level.js 2952 2015-04-01 00:33:54Z tgaskins $
  */
 define([
         '../geom/Angle',

--- a/src/util/LevelRowColumnUrlBuilder.js
+++ b/src/util/LevelRowColumnUrlBuilder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports LevelRowColumnUrlBuilder
- * @version $Id: LevelRowColumnUrlBuilder.js 2643 2015-01-09 20:37:58Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/LevelSet.js
+++ b/src/util/LevelSet.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports LevelSet
- * @version $Id: LevelSet.js 2952 2015-04-01 00:33:54Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/Logger.js
+++ b/src/util/Logger.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Logger.js 3418 2015-08-22 00:17:05Z tgaskins $
- */
 define(function () {
     "use strict";
     /**

--- a/src/util/NominatimGeocoder.js
+++ b/src/util/NominatimGeocoder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports NominatimGeocoder
- * @version $Id: NominatimGeocoder.js 3133 2015-06-02 16:48:25Z tgaskins $
  */
 define([
         '../util/Logger'

--- a/src/util/Offset.js
+++ b/src/util/Offset.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Offset
- * @version $Id: Offset.js 2958 2015-04-01 23:25:29Z tgaskins $
  */
 define(['../geom/Vec2'
     ],

--- a/src/util/PeriodicTimeSequence.js
+++ b/src/util/PeriodicTimeSequence.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports PeriodicTimeSequence
- * @version $Id: PeriodicTimeSequence.js 3362 2015-07-31 19:29:12Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/Tile.js
+++ b/src/util/Tile.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports Tile
- * @version $Id: Tile.js 3125 2015-05-29 14:43:25Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/src/util/TileFactory.js
+++ b/src/util/TileFactory.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports TileFactory
- * @version $Id: TileFactory.js 2664 2015-01-21 02:16:16Z tgaskins $
  */
 define(['../util/Logger',
         '../error/UnsupportedOperationError'

--- a/src/util/UrlBuilder.js
+++ b/src/util/UrlBuilder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports UrlBuilder
- * @version $Id: UrlBuilder.js 2938 2015-03-30 15:02:00Z tgaskins $
  */
 define(['../util/Logger',
         '../error/UnsupportedOperationError'

--- a/src/util/WWMath.js
+++ b/src/util/WWMath.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: WWMath.js 3305 2015-07-07 21:55:51Z dcollins $
- */
 define([
         '../geom/Angle',
         '../error/ArgumentError',

--- a/src/util/WWMessage.js
+++ b/src/util/WWMessage.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WWMessage
- * @version $Id: WWMessage.js 3418 2015-08-22 00:17:05Z tgaskins $
  */
 define([],
     function () {

--- a/src/util/WWUtil.js
+++ b/src/util/WWUtil.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: WWUtil.js 3402 2015-08-14 17:28:09Z tgaskins $
- */
 define([
         '../error/ArgumentError',
         '../geom/Line',

--- a/src/util/WmsUrlBuilder.js
+++ b/src/util/WmsUrlBuilder.js
@@ -4,7 +4,6 @@
  */
 /**
  * @exports WmsUrlBuilder
- * @version $Id: WmsUrlBuilder.js 3362 2015-07-31 19:29:12Z tgaskins $
  */
 define([
         '../error/ArgumentError',

--- a/test/formats/kml/geom/KmlPoint.test.js
+++ b/test/formats/kml/geom/KmlPoint.test.js
@@ -2,9 +2,6 @@
  * Copyright (C) 2014 United States Government as represented by the Administrator of the
  * National Aeronautics and Space Administration. All Rights Reserved.
  */
-/**
- * @version $Id: Vec3.test.js 2498 2014-12-01 22:21:09Z danm $
- */
 define([
     'src/util/XmlDocument',
     'src/formats/kml/geom/KmlPoint'


### PR DESCRIPTION
### Description of the Change

Remove all instances of the obsolete Subversion auto-commit keyword "@version $Id:...".

### Why Should This Be In Core?

Affects all core source code, examples, apps, and configuration files.

### Benefits

Removes obsolete and unnecessary file header clutter. Simplifies license maintenance.

### Potential Drawbacks

None.

### Applicable Issues

Done.