### PR TITLE
Repaired BlueMarbleTimeSeries example

### DIFF
--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -31,8 +31,8 @@ requirejs(['./WorldWindShim',
         backgroundLayer.hide = true; // Don't show it in the layer manager.
         wwd.addLayer(backgroundLayer);
 
-        // Create the Blue Marble time series layer.
-        var blueMarbleTimeSeries = new WorldWind.BMNGRestLayer(null);
+        // Create the Blue Marble time series layer using REST tiles hosted at worldwind32.arc.nasa.gov.
+        var blueMarbleTimeSeries = new WorldWind.BMNGRestLayer("https://worldwind32.arc.nasa.gov/standalonedata/Earth/BlueMarble256");
         blueMarbleTimeSeries.enabled = false;
         blueMarbleTimeSeries.showSpinner = true;
 

--- a/src/layer/BMNGRestLayer.js
+++ b/src/layer/BMNGRestLayer.js
@@ -59,7 +59,14 @@ define([
              */
             this.time = initialTime || new Date("2004-01");
 
-            this.pickEnabled = false;
+            // Intentionally not documented.
+            this.timeSequence = new PeriodicTimeSequence("2004-01-01/2004-12-01/P1M");
+
+            // Intentionally not documented.
+            this.serverAddress = serverAddress;
+
+            // Intentionally not documented.
+            this.pathToData = pathToData;
 
             // Intentionally not documented.
             this.layers = {}; // holds the layers as they're created.
@@ -79,10 +86,8 @@ define([
                 {month: "BlueMarble-200411", time: BMNGRestLayer.availableTimes[10]},
                 {month: "BlueMarble-200412", time: BMNGRestLayer.availableTimes[11]}
             ];
-            this.timeSequence = new PeriodicTimeSequence("2004-01-01/2004-12-01/P1M");
 
-            this.serverAddress = serverAddress;
-            this.pathToData = pathToData;
+            this.pickEnabled = false;
         };
 
         BMNGRestLayer.prototype = Object.create(Layer.prototype);
@@ -177,8 +182,14 @@ define([
         };
 
         BMNGRestLayer.prototype.createSubLayer = function (layerName) {
-            var dataPath = this.pathToData + layerName;
-            this.layers[layerName] = new RestTiledImageLayer(this.serverAddress, dataPath, this.displayName);
+            var subLayerPath = "";
+            if (this.pathToData) {
+                subLayerPath = this.pathToData + "/" + layerName;
+            } else {
+                subLayerPath = layerName;
+            }
+
+            this.layers[layerName] = new RestTiledImageLayer(this.serverAddress, subLayerPath, this.displayName);
         };
 
         // Intentionally not documented.


### PR DESCRIPTION
### Description of the Change

- Modified the example to specify a service address for BMNGRestLayer
- Adjusted BMNGRestLayer's handling of data path to accommodate both locally hosted and online REST tiles

### Why Should This Be In Core? + Benefits

Repairs the broken BlueMarbleTimeSeries example, and makes the library's BMNGRestLayer configuration more flexible.

### Potential Drawbacks

None.

### Applicable Issues

Closes #316 