### PR TITLE
Repaired example LayerManager's handling of Gnomonic projection

### DIFF
--- a/examples/LayerManager.js
+++ b/examples/LayerManager.js
@@ -88,9 +88,9 @@ define(function () {
             } else if (projectionName === "South UPS") {
                 this.flatGlobe.projection = new WorldWind.ProjectionUPS("South");
             } else if (projectionName === "North Gnomonic") {
-                this.flatGlobe.projection = new WorldWind.ProjectionUPS("North");
+                this.flatGlobe.projection = new WorldWind.ProjectionGnomonic("North");
             } else if (projectionName === "South Gnomonic") {
-                this.flatGlobe.projection = new WorldWind.ProjectionUPS("South");
+                this.flatGlobe.projection = new WorldWind.ProjectionGnomonic("South");
             }
 
             if (this.wwd.globe !== this.flatGlobe) {


### PR DESCRIPTION
### Description of the Change

- LayerManager mistakenly selected the UPS projection when it should select the Gnomonic projection
- See investigation by @Beak-man in issue #336

### Why Should This Be In Core? + Benefits

Repairs the example layer manager, and correctly demonstrates the Gnomonic projection.

### Potential Drawbacks

None.

### Applicable Issues

Closes #336