### PR TITLE
Ensure that libtess is loaded by the AreaMeasurer when WebWW is bundled

### DIFF
--- a/.idea/runConfigurations/Measurements.xml
+++ b/.idea/runConfigurations/Measurements.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Measurements" type="JavascriptDebugType" factoryName="JavaScript Debug" uri="http://localhost:63342/WebWorldWind/examples/Measurements.html">
+    <RunnerSettings RunnerId="JavascriptDebugRunner" />
+    <ConfigurationWrapper RunnerId="JavascriptDebugRunner" />
+    <method />
+  </configuration>
+</component>

--- a/src/util/measure/AreaMeasurer.js
+++ b/src/util/measure/AreaMeasurer.js
@@ -24,7 +24,8 @@ define([
         '../Logger',
         './MeasurerUtils',
         '../../geom/Sector',
-        '../../geom/Vec3'
+        '../../geom/Vec3',
+        '../libtess'
     ],
     function (Angle,
               ArgumentError,
@@ -32,7 +33,8 @@ define([
               Logger,
               MeasurerUtils,
               Sector,
-              Vec3) {
+              Vec3,
+              libtessDummy) {
         'use strict';
 
         /**
@@ -301,7 +303,7 @@ define([
          * @return {Number[]} a list of tessellated vertices
          */
         AreaMeasurer.prototype.tessellatePolygon = function (count, vertices) {
-            var tess = new window.libtess.GluTesselator();
+            var tess = new libtess.GluTesselator();
             var triangles = [];
             var coords;
 


### PR DESCRIPTION
Closes #307. See shapes/Polygons.js as reference. The same trick was implemented here. The bundled library must be used for validating the fix.

Please note that this example also suffers from a bad case of mixed content (HTTPS vs HTTP). This will be addressed as part of #340 I guess, will it?