### PR TITLE
Add missing childNodes for IE11 when traversing a WMTS capabilities document

### DIFF
--- a/src/ogc/wmts/OwsConstraint.js
+++ b/src/ogc/wmts/OwsConstraint.js
@@ -43,16 +43,17 @@ define([
 
             this.name = element.getAttribute("name");
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 
                 if (child.localName === "AllowedValues") {
                     this.allowedValues = this.allowedValues || [];
 
-                    for (var cc = 0; cc < child.children.length; cc++) {
-                        if (child.children[cc].localName === "Value") {
-                            this.allowedValues.push(child.children[cc].textContent);
+                    var childrenValues = child.children || child.childNodes;
+                    for (var cc = 0; cc < childrenValues.length; cc++) {
+                        if (childrenValues[cc].localName === "Value") {
+                            this.allowedValues.push(childrenValues[cc].textContent);
                         }
                     }
                 } else if (child.localName === "AnyValue") {

--- a/src/ogc/wmts/OwsOperationsMetadata.js
+++ b/src/ogc/wmts/OwsOperationsMetadata.js
@@ -43,7 +43,7 @@ define([
                     Logger.logMessage(Logger.LEVEL_SEVERE, "OwsOperationsMetadata", "constructor", "missingDomElement"));
             }
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 
@@ -96,7 +96,7 @@ define([
 
             operation.name = element.getAttribute("name");
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 
@@ -113,7 +113,7 @@ define([
         OwsOperationsMetadata.assembleDcp = function (element) {
             var dcp = {};
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 
@@ -141,7 +141,7 @@ define([
 
             result.url = element.getAttribute("xlink:href");
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 

--- a/src/ogc/wmts/OwsServiceIdentification.js
+++ b/src/ogc/wmts/OwsServiceIdentification.js
@@ -46,7 +46,7 @@ define([
 
             OwsDescription.call(this, element);
 
-            var children = element.children;
+            var children = element.children || element.childNodes;
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
 


### PR DESCRIPTION
Closes #362 