### PR TITLE
Repaired SurfaceImage handling of null terrain

### DIFF
--- a/src/shapes/SurfaceImage.js
+++ b/src/shapes/SurfaceImage.js
@@ -132,7 +132,15 @@ define([
          * @param {DrawContext} dc The current draw context.
          */
         SurfaceImage.prototype.render = function (dc) {
-            if (!this.enabled || !this.sector.overlaps(dc.terrain.sector)) {
+            if (!this.enabled) {
+                return;
+            }
+
+            if (!dc.terrain) {
+                return;
+            }
+
+            if (!this.sector.overlaps(dc.terrain.sector)) {
                 return;
             }
 


### PR DESCRIPTION
- DrawContext.terrain is null when no terrain tiles are in view.
- This occurs when the viewer goes underground, or looks up at the sky.
- Closes #346.