### PR TITLE
Substitute non secure protocol references for secure ones

### DIFF
--- a/apps/Explorer.html
+++ b/apps/Explorer.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="Explorer/Explorer.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <link href="Explorer/skin-lion/ui.fancytree.css" rel="stylesheet" type="text/css">
     <script src="//cdn.jsdelivr.net/jquery.fancytree/2.9.0/jquery.fancytree-all.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>

--- a/apps/Explorer.html
+++ b/apps/Explorer.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <link href="Explorer/skin-lion/ui.fancytree.css" rel="stylesheet" type="text/css">
-    <script src="//cdn.jsdelivr.net/jquery.fancytree/2.9.0/jquery.fancytree-all.min.js" type="text/javascript"></script>
+    <script src="https://cdn.jsdelivr.net/jquery.fancytree/2.9.0/jquery.fancytree-all.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="Explorer/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/Explorer/Explorer.js
+++ b/apps/Explorer/Explorer.js
@@ -63,7 +63,7 @@ define(['../../src/WorldWind',
 
             this.layersPanel.timeSeriesPlayer = this.timeSeriesPlayer;
 
-            this.serversPanel.attachServer("http://neo.sci.gsfc.nasa.gov/wms/wms");
+            this.serversPanel.attachServer("https://neo.sci.gsfc.nasa.gov/wms/wms");
         };
 
         return Explorer;

--- a/apps/Explorer/Explorer.js
+++ b/apps/Explorer/Explorer.js
@@ -63,7 +63,7 @@ define(['../../src/WorldWind',
 
             this.layersPanel.timeSeriesPlayer = this.timeSeriesPlayer;
 
-            this.serversPanel.attachServer("https://neo.sci.gsfc.nasa.gov/wms/wms");
+            this.serversPanel.attachServer("http://neo.sci.gsfc.nasa.gov/wms/wms");
         };
 
         return Explorer;

--- a/apps/NEO.html
+++ b/apps/NEO.html
@@ -7,8 +7,8 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <link rel="stylesheet" href="NEO/NEO.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="NEO/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/SentinelWMTS.html
+++ b/apps/SentinelWMTS.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="SentinelWMTS/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/SentinelWMTS.html
+++ b/apps/SentinelWMTS.html
@@ -16,7 +16,7 @@
 <div class="container">
     <div class="jumbotron">
         <h1 style="text-align:center">Sentinel WMTS</h1>
-        <h2 style="text-align:center">data from <a href="http://www.sentinel-hub.com" target="_blank">www.sentinel-hub.com</a></h2>
+        <h2 style="text-align:center">data from <a href="https://www.sentinel-hub.com" target="_blank">www.sentinel-hub.com</a></h2>
     </div>
     <div class="row">
         <div class="col-sm-3">
@@ -51,7 +51,7 @@
                 Your browser does not support HTML5 Canvas.
             </canvas>
             <p></p>
-            <p style="text-align: center;">Imagery from <a href="http://www.sentinel-hub.com" target="_blank">Sentinel Hub</a> provided by <a href="http://www.sinergise.com" target="_blank">Sinergise</a>.</p>
+            <p style="text-align: center;">Imagery from <a href="https://www.sentinel-hub.com" target="_blank">Sentinel Hub</a> provided by <a href="http://www.sinergise.com" target="_blank">Sinergise</a>.</p>
         </div>
     </div>
 </div>

--- a/apps/SentinelWMTS.html
+++ b/apps/SentinelWMTS.html
@@ -51,7 +51,7 @@
                 Your browser does not support HTML5 Canvas.
             </canvas>
             <p></p>
-            <p style="text-align: center;">Imagery from <a href="https://www.sentinel-hub.com" target="_blank">Sentinel Hub</a> provided by <a href="http://www.sinergise.com" target="_blank">Sinergise</a>.</p>
+            <p style="text-align: center;">Imagery from <a href="https://www.sentinel-hub.com" target="_blank">Sentinel Hub</a> provided by <a href="https://www.sinergise.com" target="_blank">Sinergise</a>.</p>
         </div>
     </div>
 </div>

--- a/apps/SentinelWMTS/SentinelWMTS.js
+++ b/apps/SentinelWMTS/SentinelWMTS.js
@@ -37,7 +37,7 @@ define(['../../src/WorldWind',
             * Sinergise for demonstration purposes only. You must obtain your own key at www.sentinel-hub.com before
             * using this layer in your application.
             */
-            var wmtsServer = 'http://services.sentinel-hub.com/v1/wmts/56748ba2-4a88-4854-beea-86f9afc63e35';
+            var wmtsServer = 'https://services.sentinel-hub.com/v1/wmts/56748ba2-4a88-4854-beea-86f9afc63e35';
 
             $.get(wmtsServer + '?REQUEST=GetCapabilities&SERVICE=WMTS', function (response) {
                 wmtsCapabilities = new WorldWind.WmtsCapabilities(response);

--- a/apps/SubSurface.html
+++ b/apps/SubSurface.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="SubSurface/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/USGSSlabs.html
+++ b/apps/USGSSlabs.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="USGSSlabs/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/USGSWells.html
+++ b/apps/USGSWells.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="USGSWells/app"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/apps/util/ServersPanel.js
+++ b/apps/util/ServersPanel.js
@@ -70,10 +70,12 @@ define(function () {
         serverAddress = serverAddress.trim();
 
         // Search for 'http' or 'https' (case insensitive) and substitute it for lowercase 'https'
-        serverAddress = serverAddress.replace(/http|https/i, "https");
+        console.log(serverAddress);
+        serverAddress = serverAddress.replace(/https|http/i, "https");
         if (serverAddress.lastIndexOf("https", 0) != 0) {
             serverAddress = "https://" + serverAddress;
         }
+        console.log(serverAddress);
 
         var thisExplorer = this,
             request = new XMLHttpRequest(),

--- a/apps/util/ServersPanel.js
+++ b/apps/util/ServersPanel.js
@@ -24,7 +24,7 @@ define(function () {
      * @alias ServersPanel
      * @constructor
      * @classdesc Provides a list of collapsible panels that indicate the layers associated with a WMS or other
-     * image server. Currently on WMS is supported. The user can select a server's layers and they will be added to
+     * image server. Currently only WMS is supported. The user can select a server's layers and they will be added to
      * the WorldWindow's layer list.
      * @param {WorldWindow} worldWindow The WorldWindow to associate this layers panel with.
      * @param {LayersPanel} layersPanel The layers panel managing the specified WorldWindows layer list.
@@ -69,13 +69,11 @@ define(function () {
 
         serverAddress = serverAddress.trim();
 
-        // Search for 'http' or 'https' (case insensitive) and substitute it for lowercase 'https'
-        console.log(serverAddress);
+        // Search for 'https' or 'http' (case insensitive) and substitute it for lowercase 'https'
         serverAddress = serverAddress.replace(/https|http/i, "https");
         if (serverAddress.lastIndexOf("https", 0) != 0) {
             serverAddress = "https://" + serverAddress;
         }
-        console.log(serverAddress);
 
         var thisExplorer = this,
             request = new XMLHttpRequest(),

--- a/apps/util/ServersPanel.js
+++ b/apps/util/ServersPanel.js
@@ -69,9 +69,10 @@ define(function () {
 
         serverAddress = serverAddress.trim();
 
-        serverAddress = serverAddress.replace("Http", "http");
-        if (serverAddress.lastIndexOf("http", 0) != 0) {
-            serverAddress = "http://" + serverAddress;
+        // Search for 'http' or 'https' (case insensitive) and substitute it for lowercase 'https'
+        serverAddress = serverAddress.replace(/http|https/i, "https");
+        if (serverAddress.lastIndexOf("https", 0) != 0) {
+            serverAddress = "https://" + serverAddress;
         }
 
         var thisExplorer = this,

--- a/examples/Annotations.html
+++ b/examples/Annotations.html
@@ -4,8 +4,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
+    <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/smoothness/jquery-ui.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="Annotations"
             src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>

--- a/examples/Measurements.html
+++ b/examples/Measurements.html
@@ -5,7 +5,7 @@
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="Measurements" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>

--- a/examples/Measurements.html
+++ b/examples/Measurements.html
@@ -4,9 +4,9 @@
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="Measurements" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>
 <body>

--- a/examples/StarField.html
+++ b/examples/StarField.html
@@ -4,9 +4,9 @@
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="StarField" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>
 <body>

--- a/examples/StarField.html
+++ b/examples/StarField.html
@@ -5,7 +5,7 @@
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="StarField" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>

--- a/examples/WMTS.html
+++ b/examples/WMTS.html
@@ -5,7 +5,7 @@
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="WMTS.js" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>

--- a/examples/WMTS.html
+++ b/examples/WMTS.html
@@ -4,9 +4,9 @@
     <!--NOTE: Most Web WorldWind examples use jquery, Bootstrap and requirejs but those technologies are NOT-->
     <!--required by Web WorldWind. See SimplestExample.html for an example of using Web WorldWind without them.-->
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
-    <script src="http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="WMTS.js" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>
 <body>

--- a/performance/VeryManyPaths.html
+++ b/performance/VeryManyPaths.html
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <script src="https:https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="VeryManyPaths" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>

--- a/performance/VeryManyPolygons.html
+++ b/performance/VeryManyPolygons.html
@@ -3,7 +3,7 @@
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <script src="https:https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script data-main="VeryManyPolygons" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 </head>


### PR DESCRIPTION
### Description of the Changes
- Changed `'http'` and protocol relative URL references to explicitly stated `'https'` secure ones in the `<head>` tags of every .html file. 
- Modified `apps/util/ServersPanel.js` (used in the Explorer app) so it will always use `https` as protocol for the WMS server address.
- The two links for the imagery provider's website in `apps/SentinelWMTS.html` were changed to `https`.
- In the same app, the server address' protocol was set to `https`.
- Corrected duplicate `"https:https://..."` tags in a couple of performance apps.

Every example, app, and performance app was tested in Windows 10 with [node's http-server](https://www.npmjs.com/package/http-server) with SSL enabled, following this guide:
https://stackoverflow.com/a/35231213



### Why Should This Be In Core?
The most apparent problem with mixed `http` content requested from an `https` host is what produces the following error messages:

> Mixed Content: The page at 'https://127.0.0.1:8080/examples/XXXXXX.html' was loaded over HTTPS, but requested an insecure script 'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js'. This request has been blocked; the content must be served over HTTPS.

> Mixed Content: The page at 'https://127.0.0.1:8080/examples/XXXXX.html' was loaded over HTTPS, but requested an insecure stylesheet 'http://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css'. This request has been blocked; the content must be served over HTTPS.

This avoids the bootstrap-based UI controls and jQuery functions from loading when our apps and examples are hosted in a web server with `https` enabled , producing _e.g._ the issue described in #373.

This PR fixes that problem and every remote library and CSS file can be successfully requested and loaded.

### Benefits
- The UI controls in every webpage in /examples, /apps and /performance now load correctly when hosted in an `https` web server.
- The Explorer app now always requests its imagery through `https`.
- The two performance apps with the typo now work correctly.


### Potential Drawbacks
This change won't avoid mixed content to be called when the unsecured URLs are inherent to the content that is requested, which produces warnings. Namely:

- The KML example loads placemark icons from unsecured sources. This is due to `hrefs` that are part of the .kml files themselves, as in `KML_Samples.kml`:
````xml
        <Style id="downArrowIcon">
            <IconStyle>
                <Icon>
                    <href>http://maps.google.com/mapfiles/kml/pal4/icon28.png</href>
                </Icon>
            </IconStyle>
        </Style>
        <Style id="globeIcon">
            <IconStyle>
                <Icon>
                    <href>http://maps.google.com/mapfiles/kml/pal3/icon19.png</href>
                </Icon>
            </IconStyle>
            <LineStyle>
                <width>2</width>
            </LineStyle>
        </Style>
````

- The WMTS example loads tiles from an unsecure location, even when setting the WMTS service address protocol as 'https'. This is due to the tile addresses being defined as unsecured in the GetCapabilities document from the German Space Agency:
````xml
    <ows:Operation name="GetTile">
      <ows:DCP>
        <ows:HTTP>
          <ows:Get xlink:href="http://tiles.geoservice.dlr.de/service/wmts?">
            <ows:Constraint name="GetEncoding">
              <ows:AllowedValues>
                <ows:Value>KVP</ows:Value>
              </ows:AllowedValues>
            </ows:Constraint>
          </ows:Get>
        </ows:HTTP>
      </ows:DCP>
    </ows:Operation>
````
While these examples do work in spite of this, we still get warnings such as:

> Mixed Content: The page at 'https://127.0.0.1:8080/examples/WMTS.html' was loaded over HTTPS, but requested an insecure image 'http://tiles.geoservice.dlr.de/service/wmts?service=WMTS&request=GetTile&version=1.0.0&Layer=hillshade&Style=_empty&Format=image/png&TileMatrixSet=EPSG:4326&TileMatrix=EPSG:4326:2&TileRow=3&TileCol=0'. This content should also be served over HTTPS.

### Applicable Issues
Closes #373 
Closes #340 
Does not avoid the warning in the WMTS example that's mentioned in the latter.