### PR TITLE
Issue 337: Fix incorrect error check

### DIFF
--- a/src/layer/WmtsLayer.js
+++ b/src/layer/WmtsLayer.js
@@ -472,7 +472,7 @@ define([
                 }
             }
 
-            if (!config.styleIdentifier) {
+            if (!config.style) {
                 Logger.logMessage(Logger.LEVEL_WARNING, "WmtsLayer", "formLayerConfiguration",
                     "No default style available. A style will not be specified in tile requests.");
             }


### PR DESCRIPTION
Closes #337 

### Description of the Change

WmtsLayer.formLayerConfiguration appears to be performing an error check on the wrong member variable.

### Why Should This Be In Core?

Shuts off incorrect error message.

### Benefits

Shuts off incorrect error message.

### Potential Drawbacks
 
None known.

### Applicable Issues

#337 