### PR TITLE
Refactor TiledImageLayer fade out opacity value assignment

### DIFF
--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -304,18 +304,21 @@ define([
                 if (this.previousTiles.hasOwnProperty(tileImagePath)) {
                     tile = this.previousTiles[tileImagePath];
 
-                    if (tile.opacity > 0 && !current[tile.imagePath]) {
-                        // Compute the reduced.
-                        tile.opacity = Math.max(0, tile.opacity - visibilityDelta);
+                    // Determine the new fade out opacity
+                    var reducedTileOpacity = Math.max(0, tile.opacity - visibilityDelta);
 
-                        // If not fully faded, add the tile to the list of current tiles and request a redraw so that
-                        // we'll be called continuously until all tiles have faded completely. Note that order in the
-                        // current tiles list is important: the non-opaque tiles must be drawn after the opaque tiles.
-                        if (tile.opacity > 0) {
-                            this.currentTiles.push(tile);
-                            this.currentTilesInvalid = true;
-                            dc.redrawRequested = true;
-                        }
+                    // If not fully faded, add the tile to the list of current tiles and request a redraw until all
+                    // tiles have faded completely. Note that order in the current tiles list is important:
+                    // the non-opaque tiles must be drawn after the opaque tiles.
+                    if (!current[tile.imagePath] && reducedTileOpacity > 0) {
+                        // Update the opacity
+                        tile.opacity = reducedTileOpacity;
+                        this.currentTiles.push(tile);
+                        this.currentTilesInvalid = true;
+                        dc.redrawRequested = true;
+                    } else {
+                        // reset to the default
+                        tile.opacity = 1;
                     }
                 }
             }
@@ -411,7 +414,6 @@ define([
                 if (this.isTileTextureInMemory(dc, this.currentAncestorTile)) {
                     // Set up to map the ancestor tile into the current one.
                     tile.fallbackTile = this.currentAncestorTile;
-                    tile.fallbackTile.opacity = 1;
                     this.currentTiles.push(tile);
                 }
             }

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -411,7 +411,7 @@ define([
                 if (this.isTileTextureInMemory(dc, this.currentAncestorTile)) {
                     // Set up to map the ancestor tile into the current one.
                     tile.fallbackTile = this.currentAncestorTile;
-                    tile.fallbackTile.opacity = 1;
+                    tile.opacity = 1;
                     this.currentTiles.push(tile);
                 }
             }

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -310,17 +310,15 @@ define([
                     // If not fully faded, add the tile to the list of current tiles and request a redraw until all
                     // tiles have faded completely. Note that order in the current tiles list is important:
                     // the non-opaque tiles must be drawn after the opaque tiles.
-                    if (!current[tile.imagePath]) {
-                        if (reducedTileOpacity > 0) {
-                            // Update the opacity
-                            tile.opacity = reducedTileOpacity;
-                            this.currentTiles.push(tile);
-                            this.currentTilesInvalid = true;
-                            dc.redrawRequested = true;
-                        } else {
-                            // reset to the default
-                            tile.opacity = 1;
-                        }
+                    if (!current[tile.imagePath] && reducedTileOpacity > 0) {
+                        // Update the opacity
+                        tile.opacity = reducedTileOpacity;
+                        this.currentTiles.push(tile);
+                        this.currentTilesInvalid = true;
+                        dc.redrawRequested = true;
+                    } else {
+                        // reset to the default
+                        tile.opacity = 1;
                     }
                 }
             }
@@ -398,7 +396,6 @@ define([
 
             var texture = dc.gpuResourceCache.resourceForKey(tile.imagePath);
             if (texture) {
-                tile.opacity = 1;
                 this.currentTiles.push(tile);
 
                 // If the tile's texture has expired, cause it to be re-retrieved. Note that the current,

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -310,15 +310,17 @@ define([
                     // If not fully faded, add the tile to the list of current tiles and request a redraw until all
                     // tiles have faded completely. Note that order in the current tiles list is important:
                     // the non-opaque tiles must be drawn after the opaque tiles.
-                    if (!current[tile.imagePath] && reducedTileOpacity > 0) {
-                        // Update the opacity
-                        tile.opacity = reducedTileOpacity;
-                        this.currentTiles.push(tile);
-                        this.currentTilesInvalid = true;
-                        dc.redrawRequested = true;
-                    } else {
-                        // reset to the default
-                        tile.opacity = 1;
+                    if (!current[tile.imagePath]) {
+                        if (reducedTileOpacity > 0) {
+                            // Update the opacity
+                            tile.opacity = reducedTileOpacity;
+                            this.currentTiles.push(tile);
+                            this.currentTilesInvalid = true;
+                            dc.redrawRequested = true;
+                        } else {
+                            // reset to the default
+                            tile.opacity = 1;
+                        }
                     }
                 }
             }

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -304,21 +304,18 @@ define([
                 if (this.previousTiles.hasOwnProperty(tileImagePath)) {
                     tile = this.previousTiles[tileImagePath];
 
-                    // Determine the new fade out opacity
-                    var reducedTileOpacity = Math.max(0, tile.opacity - visibilityDelta);
+                    if (tile.opacity > 0 && !current[tile.imagePath]) {
+                        // Compute the reduced.
+                        tile.opacity = Math.max(0, tile.opacity - visibilityDelta);
 
-                    // If not fully faded, add the tile to the list of current tiles and request a redraw until all
-                    // tiles have faded completely. Note that order in the current tiles list is important:
-                    // the non-opaque tiles must be drawn after the opaque tiles.
-                    if (!current[tile.imagePath] && reducedTileOpacity > 0) {
-                        // Update the opacity
-                        tile.opacity = reducedTileOpacity;
-                        this.currentTiles.push(tile);
-                        this.currentTilesInvalid = true;
-                        dc.redrawRequested = true;
-                    } else {
-                        // reset to the default
-                        tile.opacity = 1;
+                        // If not fully faded, add the tile to the list of current tiles and request a redraw so that
+                        // we'll be called continuously until all tiles have faded completely. Note that order in the
+                        // current tiles list is important: the non-opaque tiles must be drawn after the opaque tiles.
+                        if (tile.opacity > 0) {
+                            this.currentTiles.push(tile);
+                            this.currentTilesInvalid = true;
+                            dc.redrawRequested = true;
+                        }
                     }
                 }
             }
@@ -396,6 +393,7 @@ define([
 
             var texture = dc.gpuResourceCache.resourceForKey(tile.imagePath);
             if (texture) {
+                tile.opacity = 1;
                 this.currentTiles.push(tile);
 
                 // If the tile's texture has expired, cause it to be re-retrieved. Note that the current,
@@ -413,6 +411,7 @@ define([
                 if (this.isTileTextureInMemory(dc, this.currentAncestorTile)) {
                     // Set up to map the ancestor tile into the current one.
                     tile.fallbackTile = this.currentAncestorTile;
+                    tile.fallbackTile.opacity = 1;
                     this.currentTiles.push(tile);
                 }
             }

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -393,7 +393,7 @@ define([
 
             var texture = dc.gpuResourceCache.resourceForKey(tile.imagePath);
             if (texture) {
-                tile.opacity = 1;;
+                tile.opacity = 1;
                 this.currentTiles.push(tile);
 
                 // If the tile's texture has expired, cause it to be re-retrieved. Note that the current,


### PR DESCRIPTION
Closes #353 

### Description of the Change

This change moves the "reset" of a tiles opacity to the `fadeOutgoingTiles` method. The reset was previously conducted in the `addTile` method which preceded the fading stage. In some cases, the reset in the `addTile` method would override the opacity determined by the `fadeOutgoingTiles` method and cause the tile to "flicker" when the navigator was stationary.

### Why Should This Be In Core?

It consolidates the opacity state change to the relevant method and eliminates the flickering effect observed in the Standalone example.

### Applicable Issues

#353 