### PR TITLE
Change Travis Artifactory deployment bash parameter substitution method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ deploy:
       tags: true
   # Publish release distributions to the Artifactory repository
   - provider: script
-    script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/${TRAVIS_TAG#"v"}
+    script: node ./travis/publishFolderToArtifactory $ARTIFACTORY_API_KEY ./build/dist /artifactory/web/${TRAVIS_TAG:1}
     skip_cleanup: true
     on:
       tags: true


### PR DESCRIPTION
Closes #405 

### Description of the Change

At some point in the last two weeks travis-ci has stopped evaluating the bash parameter substitution method `#"v"`. Without the substitution (which removes the "v" character in the version string), the publish path to Artifactory includes the "v" (undesired). This change drops the first character and was tested in travis.
