### PR TITLE
layerManager spelling correction, format cleanup for examples

### DIFF
--- a/examples/Atmosphere.js
+++ b/examples/Atmosphere.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
     function (WorldWind,
               LayerManager) {
         "use strict";
-        
+
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         var wwd = new WorldWind.WorldWindow("canvasOne");
@@ -35,12 +35,12 @@ requirejs(['./WorldWindShim',
             layers[l].layer.enabled = layers[l].enabled;
             wwd.addLayer(layers[l].layer);
         }
-        
+
         var atmosphereLayer = new WorldWind.AtmosphereLayer();
         wwd.addLayer(atmosphereLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         var sunSimulationCheckBox = document.getElementById('sun-simulation');
         var sunInterval = 0;

--- a/examples/BasicExample.js
+++ b/examples/BasicExample.js
@@ -40,5 +40,5 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -46,7 +46,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(new WorldWind.ViewControlsLayer(wwd));
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Ensure that the background and other control layers are displayed while the blue marble layer is
         // being pre-populated.
@@ -67,7 +67,7 @@ requirejs(['./WorldWindShim',
                 blueMarbleTimeSeries.enabled = true;
                 blueMarbleTimeSeries.showSpinner = false;
                 window.clearInterval(prePopulateInterval);
-                layerManger.synchronizeLayerList();
+                layerManager.synchronizeLayerList();
 
                 // Increment the Blue Marble layer's time at a specified frequency.
                 var currentIndex = 0;

--- a/examples/Configuration.js
+++ b/examples/Configuration.js
@@ -48,5 +48,5 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/CustomPlacemark.js
+++ b/examples/CustomPlacemark.js
@@ -61,7 +61,7 @@ requirejs(['./WorldWindShim',
 
         var canvas = document.createElement("canvas"),
             ctx2d = canvas.getContext("2d"),
-            size = 64, c = size / 2  - 0.5, innerRadius = 5, outerRadius = 20;
+            size = 64, c = size / 2 - 0.5, innerRadius = 5, outerRadius = 20;
 
         canvas.width = size;
         canvas.height = size;
@@ -99,7 +99,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(placemarkLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/DeepPicking.js
+++ b/examples/DeepPicking.js
@@ -165,8 +165,8 @@ requirejs(['./WorldWindShim',
             // Create the placemark and its label.
             placemark = new WorldWind.Placemark(new WorldWind.Position(latitude, longitude + i, 1e2), false, null);
             placemark.label = "Placemark " + i.toString() + "\n"
-            + "Lat " + latitude.toPrecision(4).toString() + "\n"
-            + "Lon " + longitude.toPrecision(5).toString();
+                + "Lat " + latitude.toPrecision(4).toString() + "\n"
+                + "Lon " + longitude.toPrecision(5).toString();
             placemark.altitudeMode = WorldWind.RELATIVE_TO_GROUND;
 
             // Create the placemark attributes for this placemark. Note that the attributes differ only by their
@@ -190,5 +190,5 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(placemarkLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/DigitalGlobe.js
+++ b/examples/DigitalGlobe.js
@@ -28,8 +28,14 @@ requirejs(['./WorldWindShim',
 
         var layers = [
             {layer: new WorldWind.BMNGLayer(), enabled: true},
-            {layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe", "digitalglobe.n6ngnadl", accessToken), enabled: true},
-            {layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe with Roads", "digitalglobe.n6nhclo2", accessToken), enabled: false},
+            {
+                layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe", "digitalglobe.n6ngnadl", accessToken),
+                enabled: true
+            },
+            {
+                layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe with Roads", "digitalglobe.n6nhclo2", accessToken),
+                enabled: false
+            },
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},
             {layer: new WorldWind.ViewControlsLayer(wwd), enabled: true}
@@ -41,5 +47,5 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/GeoJSON.js
+++ b/examples/GeoJSON.js
@@ -59,22 +59,21 @@ requirejs(['./WorldWindShim',
                     configuration.attributes.imageScale = 0.01 * Math.log(population);
                 }
             }
-            else if (geometry.isLineStringType() || geometry.isMultiLineStringType()){
-                configuration.attributes =  new WorldWind.ShapeAttributes(null);
-            configuration.attributes.drawOutline = true;
-            configuration.attributes.outlineColor = new WorldWind.Color(
-                0.1 * configuration.attributes.interiorColor.red,
-                0.3 * configuration.attributes.interiorColor.green,
-                0.7 * configuration.attributes.interiorColor.blue,
-                1.0);
-            configuration.attributes.outlineWidth = 1.0;
+            else if (geometry.isLineStringType() || geometry.isMultiLineStringType()) {
+                configuration.attributes = new WorldWind.ShapeAttributes(null);
+                configuration.attributes.drawOutline = true;
+                configuration.attributes.outlineColor = new WorldWind.Color(
+                    0.1 * configuration.attributes.interiorColor.red,
+                    0.3 * configuration.attributes.interiorColor.green,
+                    0.7 * configuration.attributes.interiorColor.blue,
+                    1.0);
+                configuration.attributes.outlineWidth = 1.0;
             }
-            else if(geometry.isPolygonType() || geometry.isMultiPolygonType())
-            {
+            else if (geometry.isPolygonType() || geometry.isMultiPolygonType()) {
                 configuration.attributes = new WorldWind.ShapeAttributes(null);
 
                 // Fill the polygon with a random pastel color.
-                    configuration.attributes.interiorColor = new WorldWind.Color(
+                configuration.attributes.interiorColor = new WorldWind.Color(
                     0.375 + 0.5 * Math.random(),
                     0.375 + 0.5 * Math.random(),
                     0.375 + 0.5 * Math.random(),
@@ -87,10 +86,10 @@ requirejs(['./WorldWindShim',
                     1.0);
             }
 
-        return configuration;
+            return configuration;
         };
 
-        var parserCompletionCallback = function(layer) {
+        var parserCompletionCallback = function (layer) {
             wwd.addLayer(layer);
         };
 
@@ -186,5 +185,5 @@ requirejs(['./WorldWindShim',
 
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/GeoTiffExample.js
+++ b/examples/GeoTiffExample.js
@@ -54,6 +54,6 @@ requirejs(['./WorldWindShim',
             wwd.goTo(new WorldWind.Position(43.69, 28.54, 55000));
 
             // Create a layer manager for controlling layer visibility.
-            var layerManger = new LayerManager(wwd);
+            var layerManager = new LayerManager(wwd);
         });
     });

--- a/examples/GeographicMeshes.js
+++ b/examples/GeographicMeshes.js
@@ -87,7 +87,7 @@ requirejs(['./WorldWindShim',
 
         var canvas = document.createElement("canvas"),
             ctx2d = canvas.getContext("2d"),
-            size = 64, c = size / 2  - 0.5, innerRadius = 5, outerRadius = 20;
+            size = 64, c = size / 2 - 0.5, innerRadius = 5, outerRadius = 20;
 
         canvas.width = size;
         canvas.height = size;
@@ -132,7 +132,7 @@ requirejs(['./WorldWindShim',
         meshLayer.addRenderable(mesh);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/GeographicText.js
+++ b/examples/GeographicText.js
@@ -976,5 +976,5 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(textLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/GoToLocation.js
+++ b/examples/GoToLocation.js
@@ -46,7 +46,7 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle clicks and taps.
 

--- a/examples/KmlExample.js
+++ b/examples/KmlExample.js
@@ -53,7 +53,7 @@ requirejs(['./WorldWindShim',
         });
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/Measurements.js
+++ b/examples/Measurements.js
@@ -79,5 +79,5 @@ requirejs([
             terrainAreaSpan.textContent = (terrainArea / 1e6).toFixed(3);
         }
 
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/NDVIViewer.js
+++ b/examples/NDVIViewer.js
@@ -24,7 +24,7 @@ requirejs([
 
         // Create the WorldWindow.
         var wwd = new WorldWind.WorldWindow("canvasOne");
-        var layerManger;
+        var layerManager;
 
         // Add imagery layers
         var layers = [
@@ -40,16 +40,16 @@ requirejs([
 
         var dataJsonUrl = './data/analyticalSurfaces.json';
         var colorPaletteArray = [
-            0.0,25.5,0.701,0.921,1.0, 1.0,
-            25.5,51.0,1.0000,1.0000,0.9412, 1.0,
-            51.0,76.5,1.0000,1.0000,0.8980, 1.0,
-            76.5,102.0,0.9686,0.9882,0.7255, 1.0,
-            102.0,127.5,0.8510,0.9412,0.6392, 1.0,
-            127.5,153.0,0.6784,0.8667,0.5569, 1.0,
-            153.0,175.5,0.2549,0.6706,0.3647, 1.0,
-            175.5,204.0,0.1373,0.5176,0.2627, 1.0,
-            204.0,229.5,0.0000,0.3529,0.1608, 1.0,
-            229.5,255.0,0.0000,0.2706,0.1608, 1.0
+            0.0, 25.5, 0.701, 0.921, 1.0, 1.0,
+            25.5, 51.0, 1.0000, 1.0000, 0.9412, 1.0,
+            51.0, 76.5, 1.0000, 1.0000, 0.8980, 1.0,
+            76.5, 102.0, 0.9686, 0.9882, 0.7255, 1.0,
+            102.0, 127.5, 0.8510, 0.9412, 0.6392, 1.0,
+            127.5, 153.0, 0.6784, 0.8667, 0.5569, 1.0,
+            153.0, 175.5, 0.2549, 0.6706, 0.3647, 1.0,
+            175.5, 204.0, 0.1373, 0.5176, 0.2627, 1.0,
+            204.0, 229.5, 0.0000, 0.3529, 0.1608, 1.0,
+            229.5, 255.0, 0.0000, 0.2706, 0.1608, 1.0
         ];
 
         var sceneCounter = 0,
@@ -70,11 +70,11 @@ requirejs([
                     if (xhr.status === 200) {
                         analyticalSurfaceDataObject = JSON.parse(xhr.response);
 
-                        $( "#scene-date" ).val(getStringDateFormat(analyticalSurfaceDataObject[0].filenameList[0]));
+                        $("#scene-date").val(getStringDateFormat(analyticalSurfaceDataObject[0].filenameList[0]));
 
                         //console.log(analyticalSurfaceDataObject);
                         //show globe after loading first scene of each region (synchronous)
-                        for(var i=0; i < analyticalSurfaceDataObject.length; i++) {
+                        for (var i = 0; i < analyticalSurfaceDataObject.length; i++) {
                             analyticalSurfaceDataObject[i].paragraphId = "p" + analyticalSurfaceDataObject[i].regionName;
                             analyticalSurfaceDataObject[i].loadingStatus = 0;
                             addLoadingStatusParagraph(
@@ -82,7 +82,6 @@ requirejs([
                                 analyticalSurfaceDataObject[i].regionName,
                                 analyticalSurfaceDataObject[i].loadingStatus,
                                 analyticalSurfaceDataObject[i].filenameList.length
-
                             );
                             getNDVIData(
                                 analyticalSurfaceDataObject[i].url,
@@ -108,24 +107,24 @@ requirejs([
             xhr.send(null);
         };
 
-        function addLoadingStatusParagraph(paragraphId, regionName, loadingStatus, totalNoOfScenes){
+        function addLoadingStatusParagraph(paragraphId, regionName, loadingStatus, totalNoOfScenes) {
             var newParagraph = document.createElement('p');
             newParagraph.setAttribute("id", paragraphId)
             newParagraph.textContent = "Loading " + regionName + ": " + loadingStatus + "/" + totalNoOfScenes;
             document.getElementById("surfacesStatus").appendChild(newParagraph);
         }
 
-        function updateLoadingStatus(paragraphId, regionName, loadingStatus, totalNoOfScenes){
+        function updateLoadingStatus(paragraphId, regionName, loadingStatus, totalNoOfScenes) {
             $("#" + paragraphId).text("Loading " + regionName + ": " + loadingStatus + "/" + totalNoOfScenes);
         }
 
         function getNDVIData(url, regionName, filename, isFirstScene) {
             var url = url + filename;
             var xhr = new XMLHttpRequest();
-            if (isFirstScene){
+            if (isFirstScene) {
                 xhr.open("GET", url, false);
             }
-            else{
+            else {
                 xhr.open("GET", url, true);
             }
 
@@ -135,13 +134,13 @@ requirejs([
                         var dataArray = xhr.response.split('\n');
 
                         if (analyticalSurfaceObjectArray.filter(
-                                function(e) {
-                                    return e.regionName === regionName}
-                            ).length === 0)
-                        {
+                                function (e) {
+                                    return e.regionName === regionName
+                                }
+                            ).length === 0) {
                             // Parse ESRI Grid file
                             var ncols = Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
-                            var nrows =  Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
+                            var nrows = Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
                             var xllcorner = Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
                             var yllcorner = Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
                             var cellsize = Number(dataArray.shift().replace(/  +/g, ' ').split(' ')[1]);
@@ -157,22 +156,22 @@ requirejs([
 
                             analyticalSurfaceObjectArray.push(
                                 {
-                                    "regionName" : regionName,
-                                    "width" : ncols,
-                                    "height" : nrows,
-                                    "referenceX" : xllcorner,
-                                    "referenceY" : ytlcorner,
-                                    "cellSize" : cellsize,
-                                    "noDataValue" : NODATA_value,
-                                    "imageList" : [
+                                    "regionName": regionName,
+                                    "width": ncols,
+                                    "height": nrows,
+                                    "referenceX": xllcorner,
+                                    "referenceY": ytlcorner,
+                                    "cellSize": cellsize,
+                                    "noDataValue": NODATA_value,
+                                    "imageList": [
                                         {
-                                            "filename" : filename,
-                                            "dataArray" : dataArray,
-                                            "imageData" : imageData
+                                            "filename": filename,
+                                            "dataArray": dataArray,
+                                            "imageData": imageData
                                         }],
-                                    "canvas" : canvas,
-                                    "context2d" : context2d,
-                                    "loadingStatus:" : 0
+                                    "canvas": canvas,
+                                    "context2d": context2d,
+                                    "loadingStatus:": 0
                                 }
                             );
 
@@ -184,11 +183,10 @@ requirejs([
                                 imageData,
                                 NODATA_value);
                         }
-                        else
-                        {
+                        else {
                             dataArray.splice(0, 6);
 
-                            var index =  getIndexOfObjectsArrayByAttribute(
+                            var index = getIndexOfObjectsArrayByAttribute(
                                 analyticalSurfaceObjectArray,
                                 "regionName",
                                 regionName);
@@ -199,9 +197,9 @@ requirejs([
 
                             analyticalSurfaceObjectArray[index].imageList.push(
                                 {
-                                    "filename" : filename,
-                                    "dataArray" : dataArray,
-                                    "imageData" : imageData
+                                    "filename": filename,
+                                    "dataArray": dataArray,
+                                    "imageData": imageData
                                 }
                             );
 
@@ -234,7 +232,7 @@ requirejs([
             xhr.send(null);
         };
 
-        function compareFilename(a,b) {
+        function compareFilename(a, b) {
             if (a.filename < b.filename)
                 return -1;
             if (a.filename > b.filename)
@@ -244,7 +242,7 @@ requirejs([
 
         function createAnalyticalSurfaceLayer(analyticalSurfaceArray) {
             var surfaceLayerArray = [];
-            for (var i = 0; i < analyticalSurfaceArray.length; i++){
+            for (var i = 0; i < analyticalSurfaceArray.length; i++) {
                 var analyticalSurfaceLayer = new WorldWind.RenderableLayer();
                 analyticalSurfaceLayer.displayName = analyticalSurfaceArray[i].regionName;
 
@@ -265,8 +263,8 @@ requirejs([
             return surfaceLayerArray;
         }
 
-        function doGetNDVIDataAsync(j, k){
-            setTimeout(function() {
+        function doGetNDVIDataAsync(j, k) {
+            setTimeout(function () {
                 getNDVIData(
                     analyticalSurfaceDataObject[j].url,
                     analyticalSurfaceDataObject[j].regionName,
@@ -278,7 +276,7 @@ requirejs([
         function getImage(dataArray, regionName, filename, context2d, imageData, noDataValue) {
             var worker = new Worker('CanvasWorker.js');
 
-            worker.onmessage = function(e) {
+            worker.onmessage = function (e) {
 
                 sceneCounter++;
 
@@ -307,13 +305,13 @@ requirejs([
                     analyticalSurfaceDataObject[regionIndex].filenameList.length
                 );
 
-                if (sceneCounter === analyticalSurfaceDataObject.length && !isFirstSceneDraw){
+                if (sceneCounter === analyticalSurfaceDataObject.length && !isFirstSceneDraw) {
                     context2d.putImageData(e.data.imageData, 0, 0);
 
                     surfaceLayerArrayGlobal = createAnalyticalSurfaceLayer(analyticalSurfaceObjectArray);
 
                     //add regions to select control
-                    for(var i=0; i< surfaceLayerArrayGlobal.length; i++){
+                    for (var i = 0; i < surfaceLayerArrayGlobal.length; i++) {
                         $('#select-region').append($('<option>', {
                             value: surfaceLayerArrayGlobal[i].displayName,
                             text: surfaceLayerArrayGlobal[i].displayName
@@ -321,22 +319,22 @@ requirejs([
                         wwd.addLayer(surfaceLayerArrayGlobal[i]);
                     }
 
-                    layerManger = new LayerManager(wwd);
-                    layerManger.goToAnimator.goTo(new WorldWind.Position(41.77, 12.77, 40000));
+                    layerManager = new LayerManager(wwd);
+                    layerManager.goToAnimator.goTo(new WorldWind.Position(41.77, 12.77, 40000));
                     isFirstSceneDraw = true;
 
                     //start load async other scenes
-                    for(var j = 0; j < analyticalSurfaceDataObject.length; j++){
-                        for(var k = 1; k < analyticalSurfaceDataObject[j].filenameList.length; k++){
+                    for (var j = 0; j < analyticalSurfaceDataObject.length; j++) {
+                        for (var k = 1; k < analyticalSurfaceDataObject[j].filenameList.length; k++) {
                             doGetNDVIDataAsync(j, k);
                         }
                     }
-                }else if (sceneCounter < analyticalSurfaceDataObject.length && !isFirstSceneDraw){
+                } else if (sceneCounter < analyticalSurfaceDataObject.length && !isFirstSceneDraw) {
                     context2d.putImageData(e.data.imageData, 0, 0);
                 }
             };
 
-            worker.onerror = function(e) {
+            worker.onerror = function (e) {
                 alert('Error: Line ' + e.lineno + ' in ' + e.filename + ': ' + e.message);
             };
 
@@ -345,35 +343,37 @@ requirejs([
                 'imageData': imageData,
                 'dataArray': dataArray,
                 'colorPaletteArray': colorPaletteArray,
-                'regionName' : regionName,
-                'filename' : filename,
-                'noDataValue' : noDataValue
+                'regionName': regionName,
+                'filename': filename,
+                'noDataValue': noDataValue
             });
         }
 
-        function getStringDateFormat(filename){
+        function getStringDateFormat(filename) {
             var dataField = filename.split("_")[4];
-            return dataField.substring(0,4) + "/" + dataField.substring(4,6) + "/" + dataField.substring(6,8);
+            return dataField.substring(0, 4) + "/" + dataField.substring(4, 6) + "/" + dataField.substring(6, 8);
         }
 
-        function changeTransparencyValue(value){
-            for (var i=0; i < wwd.layers.length; i++ ){
-                if (wwd.layers[i].displayName === ($( "#select-region" ).val())) {
-                    for(var j=0; j < wwd.layers[i].renderables.length; j++){
+        function changeTransparencyValue(value) {
+            for (var i = 0; i < wwd.layers.length; i++) {
+                if (wwd.layers[i].displayName === ($("#select-region").val())) {
+                    for (var j = 0; j < wwd.layers[i].renderables.length; j++) {
                         wwd.layers[i].renderables[j].opacity = value;
                     }
                 }
             }
-            $( "#transparency" ).val( value );
+            $("#transparency").val(value);
         }
 
-        function getIndexOfObjectsArrayByAttribute(array, attribute, attributeValue){
-            return array.map(function(e) { return e[attribute]; }).indexOf(attributeValue);
+        function getIndexOfObjectsArrayByAttribute(array, attribute, attributeValue) {
+            return array.map(function (e) {
+                return e[attribute];
+            }).indexOf(attributeValue);
         }
 
-        function changeParamValues(value){
-            for (var i=0; i < wwd.layers.length; i++ ){
-                if (wwd.layers[i].displayName === ($( "#select-region" ).val())) {
+        function changeParamValues(value) {
+            for (var i = 0; i < wwd.layers.length; i++) {
+                if (wwd.layers[i].displayName === ($("#select-region").val())) {
                     var regionIndex = getIndexOfObjectsArrayByAttribute(
                         analyticalSurfaceObjectArray,
                         "regionName",
@@ -386,7 +386,7 @@ requirejs([
                         analyticalSurfaceObjectArray[regionIndex].canvas);
 
                     var filename = analyticalSurfaceObjectArray[regionIndex].imageList[value].filename;
-                    $( "#scene-date" ).val( getStringDateFormat(filename));
+                    $("#scene-date").val(getStringDateFormat(filename));
 
                     wwd.redraw();
                     break;
@@ -409,7 +409,7 @@ requirejs([
             if (pickList.objects.length > 0) {
                 for (var p = 0; p < pickList.objects.length; p++) {
                     if (pickList.objects[p].userObject instanceof WorldWind.SurfaceImage) {
-                        if (pickList.objects[p].userObject.displayName === ($( "#select-region" ).val())){
+                        if (pickList.objects[p].userObject.displayName === ($("#select-region").val())) {
                             var index = getIndexOfObjectsArrayByAttribute(
                                 analyticalSurfaceObjectArray,
                                 "regionName",
@@ -434,12 +434,12 @@ requirejs([
                             var data = [];
                             var xLabels = [];
 
-                            for(var i=0; i < analyticalSurfaceObjectArray[index].imageList.length;i++ ){
+                            for (var i = 0; i < analyticalSurfaceObjectArray[index].imageList.length; i++) {
                                 if (analyticalSurfaceObjectArray[index].imageList[i].dataArray[indexParam] ===
-                                    analyticalSurfaceObjectArray[index].noDataValue){
+                                    analyticalSurfaceObjectArray[index].noDataValue) {
                                     data.push(0);
                                 }
-                                else{
+                                else {
                                     data.push(analyticalSurfaceObjectArray[index].imageList[i].dataArray[indexParam]);
                                 }
                                 xLabels.push(
@@ -453,7 +453,7 @@ requirejs([
                             var step = w / data.length;
 
                             var domainArray = [];
-                            for (var i = 0; i < data.length; i ++){
+                            for (var i = 0; i < data.length; i++) {
                                 domainArray.push(i * step);
                             }
 
@@ -462,10 +462,10 @@ requirejs([
                             var y = d3.scale.linear().domain([0, 255]).range([h, 0]);
 
                             var line = d3.svg.line()
-                                .x(function(d,i) {
+                                .x(function (d, i) {
                                     return x(i);
                                 })
-                                .y(function(d) {
+                                .y(function (d) {
                                     return y(d);
                                 });
 
@@ -487,7 +487,7 @@ requirejs([
                                 .style("text-anchor", "end")
                                 .attr("dx", "-.8em")
                                 .attr("dy", ".15em")
-                                .attr("transform", "rotate(-65)" );;
+                                .attr("transform", "rotate(-65)");
 
                             var yAxisLeft = d3.svg.axis().scale(y).ticks(4).orient("left");
                             svg.append("svg:g")
@@ -508,45 +508,45 @@ requirejs([
         // Listen for taps on mobile devices and highlight the placemarks that the user taps.
         var tapRecognizer = new WorldWind.TapRecognizer(wwd, handlePick);
 
-        $( "#scene-slider" ).slider({
+        $("#scene-slider").slider({
             orientation: "horizontal",
             range: "min",
             min: 0,
             max: 12,
             value: 0,
-            slide: function( event, ui ) {
+            slide: function (event, ui) {
                 changeParamValues(ui.value);
             }
         });
 
-        $( "#transparency-slider" ).slider({
+        $("#transparency-slider").slider({
             orientation: "horizontal",
             range: "min",
             min: 0.0,
             max: 1.0,
             step: 0.01,
             value: 1.0,
-            slide: function( event, ui ) {
+            slide: function (event, ui) {
                 changeTransparencyValue(ui.value);
             }
         });
-        $( "#transparency" ).val( 1.0 );
+        $("#transparency").val(1.0);
 
-        $( "#select-region" ).change(function() {
+        $("#select-region").change(function () {
             var str = "";
-            $( "select option:selected" ).each(function() {
-                str += $( this ).text();
+            $("select option:selected").each(function () {
+                str += $(this).text();
             });
 
-            if (str === "Sicily"){
-                layerManger.goToAnimator.goTo(new WorldWind.Position(37.51, 14.00, 400000));
-            }else if (str === "Rome"){
-                layerManger.goToAnimator.goTo(new WorldWind.Position(41.77, 12.77, 40000));
+            if (str === "Sicily") {
+                layerManager.goToAnimator.goTo(new WorldWind.Position(37.51, 14.00, 400000));
+            } else if (str === "Rome") {
+                layerManager.goToAnimator.goTo(new WorldWind.Position(41.77, 12.77, 40000));
             }
 
-            for (var i=0; i < analyticalSurfaceObjectArray.length; i++){
-                if (analyticalSurfaceObjectArray[i].regionName === str){
-                    $( "#scene-slider" ).slider("option", "max", analyticalSurfaceObjectArray[i].imageList.length - 1);
+            for (var i = 0; i < analyticalSurfaceObjectArray.length; i++) {
+                if (analyticalSurfaceObjectArray[i].regionName === str) {
+                    $("#scene-slider").slider("option", "max", analyticalSurfaceObjectArray[i].imageList.length - 1);
                     break;
                 }
             }

--- a/examples/ParseUrlArguments.js
+++ b/examples/ParseUrlArguments.js
@@ -66,10 +66,10 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now move the view to the requested position.
-        if  (args.position) {
+        if (args.position) {
             wwd.goTo(args.position);
         }
     });

--- a/examples/Paths.js
+++ b/examples/Paths.js
@@ -78,7 +78,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(pathsLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/PickAllShapesInRegion.js
+++ b/examples/PickAllShapesInRegion.js
@@ -94,7 +94,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(placemarkLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 

--- a/examples/PlacemarksAndPicking.js
+++ b/examples/PlacemarksAndPicking.js
@@ -96,8 +96,8 @@ requirejs(['./WorldWindShim',
             // Create the placemark and its label.
             placemark = new WorldWind.Placemark(new WorldWind.Position(latitude, longitude + i, 1e2), true, null);
             placemark.label = "Placemark " + i.toString() + "\n"
-            + "Lat " + placemark.position.latitude.toPrecision(4).toString() + "\n"
-            + "Lon " + placemark.position.longitude.toPrecision(5).toString();
+                + "Lat " + placemark.position.latitude.toPrecision(4).toString() + "\n"
+                + "Lon " + placemark.position.longitude.toPrecision(5).toString();
             placemark.altitudeMode = WorldWind.RELATIVE_TO_GROUND;
 
             // Create the placemark attributes for this placemark. Note that the attributes differ only by their
@@ -121,7 +121,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(placemarkLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 

--- a/examples/Polygons.js
+++ b/examples/Polygons.js
@@ -186,7 +186,7 @@ requirejs(['./WorldWindShim',
 
         var canvas = document.createElement("canvas"),
             ctx2d = canvas.getContext("2d"),
-            size = 64, c = size / 2  - 0.5, innerRadius = 5, outerRadius = 20;
+            size = 64, c = size / 2 - 0.5, innerRadius = 5, outerRadius = 20;
 
         canvas.width = size;
         canvas.height = size;
@@ -219,7 +219,7 @@ requirejs(['./WorldWindShim',
         polygonsLayer.addRenderable(polygon);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/RefreshImagery.js
+++ b/examples/RefreshImagery.js
@@ -42,7 +42,7 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Set up to refresh the imagery periodically.
         setInterval(function () {

--- a/examples/ScreenImage.js
+++ b/examples/ScreenImage.js
@@ -55,7 +55,7 @@ requirejs(['./WorldWindShim',
 
         var canvas = document.createElement("canvas"),
             ctx2d = canvas.getContext("2d"),
-            size = 64, c = size / 2  - 0.5, innerRadius = 5, outerRadius = 20;
+            size = 64, c = size / 2 - 0.5, innerRadius = 5, outerRadius = 20;
 
         canvas.width = size;
         canvas.height = size;
@@ -82,7 +82,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(screenImageLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -97,7 +97,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(textLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Set up to handle picking.
         var handlePick = (function (o) {

--- a/examples/Shapefiles.js
+++ b/examples/Shapefiles.js
@@ -100,5 +100,5 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(fortStoryLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/examples/StarField.js
+++ b/examples/StarField.js
@@ -39,7 +39,7 @@ requirejs([
         starFieldLayer.time = date;
         atmosphereLayer.time = date;
 
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
         wwd.redraw();
 
         wwd.redrawCallbacks.push(runSunSimulation);

--- a/examples/SurfaceImage.js
+++ b/examples/SurfaceImage.js
@@ -47,13 +47,13 @@ requirejs(['./WorldWindShim',
 
         // Create a surface image using a static image.
         var surfaceImage1 = new WorldWind.SurfaceImage(new WorldWind.Sector(40, 50, -120, -100),
-        "data/400x230-splash-nww.png");
+            "data/400x230-splash-nww.png");
 
         // Create a surface image using a dynamically created image.
 
         var canvas = document.createElement("canvas"),
             ctx2d = canvas.getContext("2d"),
-            size = 64, c = size / 2  - 0.5, innerRadius = 5, outerRadius = 20;
+            size = 64, c = size / 2 - 0.5, innerRadius = 5, outerRadius = 20;
 
         canvas.width = size;
         canvas.height = size;
@@ -78,7 +78,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(surfaceImageLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 

--- a/examples/SurfaceShapes.js
+++ b/examples/SurfaceShapes.js
@@ -120,7 +120,7 @@ requirejs(['./WorldWindShim',
         shapesLayer.addRenderable(shape);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/TestMovingSurfaceShapes.js
+++ b/examples/TestMovingSurfaceShapes.js
@@ -137,7 +137,7 @@ requirejs(['./WorldWindShim',
         shapesLayer.addRenderable(polarEllipse);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Create a highlight controller for highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/TriangleMeshes.js
+++ b/examples/TriangleMeshes.js
@@ -159,7 +159,7 @@ requirejs(['./WorldWindShim',
         meshLayer.addRenderable(mesh);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle highlighting.
         var highlightController = new WorldWind.HighlightController(wwd);

--- a/examples/WMS.js
+++ b/examples/WMS.js
@@ -42,7 +42,7 @@ requirejs(['./WorldWindShim',
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Web Map Service information from NASA's Near Earth Observations WMS
         var serviceAddress = "https://neo.sci.gsfc.nasa.gov/wms/wms?SERVICE=WMS&REQUEST=GetCapabilities&VERSION=1.3.0";
@@ -64,7 +64,7 @@ requirejs(['./WorldWindShim',
 
             // Add the layers to WorldWind and update the layer manager
             wwd.addLayer(wmsLayer);
-            layerManger.synchronizeLayerList();
+            layerManager.synchronizeLayerList();
         };
 
         // Called if an error occurs during WMS Capabilities document retrieval

--- a/examples/WMTS.js
+++ b/examples/WMTS.js
@@ -44,7 +44,7 @@ requirejs([
         }
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Web Map Tiling Service information from
         var serviceAddress = "https://tiles.geoservice.dlr.de/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&VERSION=1.0.0";
@@ -64,8 +64,8 @@ requirejs([
 
             // Add the layers to WorldWind and update the layer manager
             wwd.addLayer(wmtsLayer);
-            layerManger.synchronizeLayerList();
-        }
+            layerManager.synchronizeLayerList();
+        };
 
         // Called if an error occurs during WMTS Capabilities document retrieval
         var logError = function (jqXhr, text, exception) {

--- a/examples/Wkt.js
+++ b/examples/Wkt.js
@@ -51,13 +51,13 @@ requirejs(['./WorldWindShim',
         // Using the callback mechanism presented in the Wkt parser to update the shapes as well as showing the information about the successful rendering.
         var customCallbackLayer = new WorldWind.RenderableLayer("WKT Multi Polygon");
         new WorldWind.Wkt("MULTIPOLYGON (((50 -60, 55 -70, 50 -80)),((30 -60, 35 -70, 30 -80)))").load(
-            function completionCallback(wkt, objects){
+            function completionCallback(wkt, objects) {
                 // Once all the shapes are parsed, this function is called.
                 console.log('Parsing of the Wkt was completed');
 
                 wkt.defaultParserCompletionCallback(wkt, objects);
             },
-            function shapeConfigurationCallback(shape){
+            function shapeConfigurationCallback(shape) {
                 if (shape.type == WorldWind.WktType.SupportedGeometries.MULTI_POLYGON) {
                     var shapeAttributes = new WorldWind.ShapeAttributes(null);
                     shapeAttributes.interiorColor = WorldWind.Color.GREEN;
@@ -72,11 +72,11 @@ requirejs(['./WorldWindShim',
 
         // Allow for parsing of your own Well known text data
         var wktLayer = new WorldWind.RenderableLayer('WKT Custom');
-        $('#showWkt').click(function(){
+        $('#showWkt').click(function () {
             new WorldWind.Wkt($('#wkt').val()).load(null, null, wktLayer);
         });
         wwd.addLayer(wktLayer);
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
     });

--- a/performance/ShapefilesComplex.js
+++ b/performance/ShapefilesComplex.js
@@ -189,7 +189,7 @@ requirejs(['../src/WorldWind',
         wwd.redraw();
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Create a coordinate controller to update the coordinate overlay elements.
         var coordinateController = new CoordinateController(wwd);

--- a/performance/SurfaceShapesComplex.js
+++ b/performance/SurfaceShapesComplex.js
@@ -231,7 +231,7 @@ requirejs(['../src/WorldWind',
         wwd.redraw();
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Create a coordinate controller to update the coordinate overlay elements.
         var coordinateController = new CoordinateController(wwd);
@@ -281,7 +281,7 @@ requirejs(['../src/WorldWind',
 
             var pickList;
 
-            if (isRegionPicking){
+            if (isRegionPicking) {
                 wwd.deepPicking = false;
 
                 // Perform the pick. Must first convert from window coordinates to canvas coordinates, which are
@@ -316,7 +316,7 @@ requirejs(['../src/WorldWind',
             }
         };
 
-        var handleMouseDown = function(o) {
+        var handleMouseDown = function (o) {
             firstX = o.clientX;
             firstY = o.clientY;
         };
@@ -332,7 +332,7 @@ requirejs(['../src/WorldWind',
         var tapRecognizer = new WorldWind.TapRecognizer(wwd, handlePick);
     },
 
-    perfTestBullseyes = function(layer) {
+    perfTestBullseyes = function (layer) {
         var center = new WorldWind.Location(39.883635, -98.545936);
 
         var shapeAttributesRed = new WorldWind.ShapeAttributes(null);
@@ -367,7 +367,7 @@ requirejs(['../src/WorldWind',
         // console.log("Number of shapeCircles generated: " + numCircles.toString());
     },
 
-    perfTestSpiral = function(layer) {
+    perfTestSpiral = function (layer) {
         var center = new WorldWind.Location(20.395127, -170.264684);
 
         var shapeAttributesRed = new WorldWind.ShapeAttributes(null);
@@ -411,7 +411,7 @@ requirejs(['../src/WorldWind',
         // console.log("Number of ShapeEllipse generated: " + numRectangles.toString());
     },
 
-    perfTestSponge = function(layer) {
+    perfTestSponge = function (layer) {
         var shapeAttributesRed = new WorldWind.ShapeAttributes(null);
         shapeAttributesRed.interiorColor = WorldWind.Color.RED;
         shapeAttributesRed.outlineColor = WorldWind.Color.BLACK;
@@ -432,7 +432,7 @@ requirejs(['../src/WorldWind',
             shapeAttributesRed, shapeAttributesWhite, shapeAttributesYellow);
     },
 
-    perfTestSpongeStep = function(layer, depth, location0, location1, location2, shapeAttributeEven, shapeAttributeOdd, shapeAttributeHighlight) {
+    perfTestSpongeStep = function (layer, depth, location0, location1, location2, shapeAttributeEven, shapeAttributeOdd, shapeAttributeHighlight) {
         var shapeBoundary = [
             location0,
             location1,
@@ -461,7 +461,7 @@ requirejs(['../src/WorldWind',
         perfTestSpongeStep(layer, depth - 1, location2, location20, location12, shapeAttributeOdd, shapeAttributeEven, shapeAttributeHighlight);
     },
 
-    china = function() {
+    china = function () {
         return [
             new WorldWind.Location(27.3208271811, 88.9169272233),
             new WorldWind.Location(27.5424270997, 88.7646362564),

--- a/performance/VeryManyPaths.js
+++ b/performance/VeryManyPaths.js
@@ -95,7 +95,7 @@ requirejs(['../src/WorldWind',
         wwd.redraw();
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 

--- a/performance/VeryManyPolygons.js
+++ b/performance/VeryManyPolygons.js
@@ -93,7 +93,7 @@ requirejs(['../src/WorldWind',
         wwd.redraw();
 
         // Create a layer manager for controlling layer visibility.
-        var layerManger = new LayerManager(wwd);
+        var layerManager = new LayerManager(wwd);
 
         // Now set up to handle picking.
 


### PR DESCRIPTION
Closes #408

### Description of the Change
Fix for misspelled variable name in most examples and apps. Also includes some format/lint cleanup.
### Why Should This Be In Core?
This change makes the code more readable.
### Benefits
See above.
