### PR TITLE
Renamed TextSupport class and instances as TextRenderer

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -211,7 +211,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         './globe/Tessellator',
         './shapes/Text',
         './shapes/TextAttributes',
-        './render/TextSupport',
+        './render/TextRenderer',
         './render/Texture',
         './render/TextureTile',
         './util/Tile',
@@ -452,7 +452,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
               Tessellator,
               Text,
               TextAttributes,
-              TextSupport,
+              TextRenderer,
               Texture,
               TextureTile,
               Tile,
@@ -851,7 +851,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         WorldWind['Tessellator'] = Tessellator;
         WorldWind['Text'] = Text;
         WorldWind['TextAttributes'] = TextAttributes;
-        WorldWind['TextSupport'] = TextSupport;
+        WorldWind['TextRenderer'] = TextRenderer;
         WorldWind['Texture'] = Texture;
         WorldWind['TextureTile'] = TextureTile;
         WorldWind['Tile'] = Tile;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -39,7 +39,7 @@ define([
         '../shapes/SurfaceShape',
         '../shapes/SurfaceShapeTileBuilder',
         '../render/SurfaceTileRenderer',
-        '../render/TextSupport',
+        '../render/TextRenderer',
         '../geom/Vec2',
         '../geom/Vec3',
         '../util/WWMath'
@@ -66,7 +66,7 @@ define([
               SurfaceShape,
               SurfaceShapeTileBuilder,
               SurfaceTileRenderer,
-              TextSupport,
+              TextRenderer,
               Vec2,
               Vec3,
               WWMath) {
@@ -145,10 +145,10 @@ define([
             this.screenCreditController = new ScreenCreditController();
 
             /**
-             * A shared TextSupport instance.
-             * @type {TextSupport}
+             * A shared TextRenderer instance.
+             * @type {TextRenderer}
              */
-            this.textSupport = new TextSupport();
+            this.textRenderer = new TextRenderer();
 
             /**
              * The current WebGL framebuffer. Null indicates that the default WebGL framebuffer is active.

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -264,7 +264,7 @@ define([
             textureKey = credit.text + this.creditFont.toString();
             activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!activeTexture) {
-                activeTexture = dc.textSupport.createTexture(dc, credit.text, this.creditFont, false);
+                activeTexture = dc.textRenderer.createTexture(dc, credit.text, this.creditFont, false);
                 dc.gpuResourceCache.putResource(textureKey, activeTexture, activeTexture.size);
             }
 

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * @exports TextSupport
+ * @exports TextRenderer
  */
 define([
         '../error/ArgumentError',
@@ -35,14 +35,14 @@ define([
         "use strict";
 
         /**
-         * Constructs a TextSupport instance.
-         * @alias TextSupport
+         * Constructs a TextRenderer instance.
+         * @alias TextRenderer
          * @constructor
          * @classdesc Provides methods useful for displaying text. An instance of this class is attached to the
          * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically do
          * not create instances of this class.
          */
-        var TextSupport = function () {
+        var TextRenderer = function () {
 
             // Internal use only. Intentionally not documented.
             this.canvas2D = document.createElement("canvas");
@@ -67,7 +67,7 @@ define([
          * @param {Boolean} outline Indicates whether the text includes an outline, which increases its width and height.
          * @returns {Vec2} A vector indicating the text's width and height, respectively, in pixels.
          */
-        TextSupport.prototype.textSize = function (text, font, outline) {
+        TextRenderer.prototype.textSize = function (text, font, outline) {
             if (text.length === 0) {
                 return new Vec2(0, 0);
             }
@@ -98,7 +98,7 @@ define([
          * @param {Boolean} outline Indicates whether the text is drawn with a thin black outline.
          * @returns {Texture} A texture for the specified text string and font.
          */
-        TextSupport.prototype.createTexture = function (dc, text, font, outline) {
+        TextRenderer.prototype.createTexture = function (dc, text, font, outline) {
             var gl = dc.currentGlContext,
                 ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
@@ -145,25 +145,25 @@ define([
          * @param {Font} font The font to use.
          * @returns {Vec2} A vector indicating the text's width and height, respectively, in pixels based on the passed font.
          */
-        TextSupport.prototype.getMaxLineHeight = function(font)
+        TextRenderer.prototype.getMaxLineHeight = function(font)
         {
             // Check underscore + capital E with acute accent
             return this.textSize("_\u00c9", font, 0)[1];
         };
 
         /**
-         * Wraps the text based on width and height using new linew delimiter
+         * Wraps the text based on width and height using new line delimiter
          * @param {String} text The text to wrap.
          * @param {Number} width The width in pixels.
          * @param {Number} height The height in pixels.
          * @param {Font} font The font to use.
          * @returns {String} The wrapped text.
          */
-        TextSupport.prototype.wrap = function(text, width, height, font)
+        TextRenderer.prototype.wrap = function(text, width, height, font)
         {
             if (!text) {
                 throw new ArgumentError(
-                    Logger.logMessage(Logger.WARNING, "TextSupport", "wrap", "missing text"));
+                    Logger.logMessage(Logger.WARNING, "TextRenderer", "wrap", "missing text"));
             }
 
             var i;
@@ -225,7 +225,7 @@ define([
          * @param {Font} font The font to use.
          * @returns {String} The wrapped text.
          */
-        TextSupport.prototype.wrapLine = function(text, width, font)
+        TextRenderer.prototype.wrapLine = function(text, width, font)
         {
             var wrappedText = "";
 
@@ -288,5 +288,5 @@ define([
             return wrappedText;
         };
 
-        return TextSupport;
+        return TextRenderer;
     });

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -145,8 +145,7 @@ define([
          * @param {Font} font The font to use.
          * @returns {Vec2} A vector indicating the text's width and height, respectively, in pixels based on the passed font.
          */
-        TextRenderer.prototype.getMaxLineHeight = function(font)
-        {
+        TextRenderer.prototype.getMaxLineHeight = function (font) {
             // Check underscore + capital E with acute accent
             return this.textSize("_\u00c9", font, 0)[1];
         };
@@ -159,8 +158,7 @@ define([
          * @param {Font} font The font to use.
          * @returns {String} The wrapped text.
          */
-        TextRenderer.prototype.wrap = function(text, width, height, font)
-        {
+        TextRenderer.prototype.wrap = function (text, width, height, font) {
             if (!text) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.WARNING, "TextRenderer", "wrap", "missing text"));
@@ -172,8 +170,7 @@ define([
             var wrappedText = "";
 
             // Wrap each line
-            for (i = 0; i < lines.length; i++)
-            {
+            for (i = 0; i < lines.length; i++) {
                 lines[i] = this.wrapLine(lines[i], width, font);
             }
             // Concatenate all lines in one string with new line separators
@@ -182,21 +179,17 @@ define([
             var currentHeight = 0;
             var heightExceeded = false;
             var maxLineHeight = this.getMaxLineHeight(font);
-            for (i = 0; i < lines.length && !heightExceeded; i++)
-            {
+            for (i = 0; i < lines.length && !heightExceeded; i++) {
                 var subLines = lines[i].split("\n");
-                for (var j = 0; j < subLines.length && !heightExceeded; j++)
-                {
-                    if (height <= 0 || currentHeight + maxLineHeight <= height)
-                    {
+                for (var j = 0; j < subLines.length && !heightExceeded; j++) {
+                    if (height <= 0 || currentHeight + maxLineHeight <= height) {
                         wrappedText += subLines[j];
                         currentHeight += maxLineHeight + this.lineSpacing;
                         if (j < subLines.length - 1) {
                             wrappedText += '\n';
                         }
                     }
-                    else
-                    {
+                    else {
                         heightExceeded = true;
                     }
                 }
@@ -206,8 +199,7 @@ define([
                 }
             }
             // Add continuation string if text truncated
-            if (heightExceeded)
-            {
+            if (heightExceeded) {
                 if (wrappedText.length > 0) {
                     wrappedText = wrappedText.substring(0, wrappedText.length - 1);
                 }
@@ -225,21 +217,18 @@ define([
          * @param {Font} font The font to use.
          * @returns {String} The wrapped text.
          */
-        TextRenderer.prototype.wrapLine = function(text, width, font)
-        {
+        TextRenderer.prototype.wrapLine = function (text, width, font) {
             var wrappedText = "";
 
             // Single line - trim leading and trailing spaces
             var source = text.trim();
             var lineBounds = this.textSize(source, font, 0);
-            if (lineBounds[0] > width)
-            {
+            if (lineBounds[0] > width) {
                 // Split single line to fit preferred width
                 var line = "";
                 var start = 0;
                 var end = source.indexOf(' ', start + 1);
-                while (start < source.length)
-                {
+                while (start < source.length) {
                     if (end == -1) {
                         end = source.length;   // last word
                     }
@@ -247,40 +236,34 @@ define([
                     // Extract a 'word' which is in fact a space and a word
                     var word = source.substring(start, end);
                     var linePlusWord = line + word;
-                    if (this.textSize(linePlusWord, font, 0)[0] <= width)
-                    {
+                    if (this.textSize(linePlusWord, font, 0)[0] <= width) {
                         // Keep adding to the current line
                         line += word;
                     }
-                    else
-                    {
+                    else {
                         // Width exceeded
-                        if (line.length != 0)
-                        {
+                        if (line.length != 0) {
                             // Finish current line and start new one
                             wrappedText += line;
                             wrappedText += '\n';
                             line = "";
                             line += word.trim();  // get read of leading space(s)
                         }
-                        else
-                        {
+                        else {
                             // Line is empty, force at least one word
                             line += word.trim();
                         }
                     }
                     // Move forward in source string
                     start = end;
-                    if (start < source.length - 1)
-                    {
+                    if (start < source.length - 1) {
                         end = source.indexOf(' ', start + 1);
                     }
                 }
                 // Gather last line
                 wrappedText += line;
             }
-            else
-            {
+            else {
                 // Line doesn't need to be wrapped
                 wrappedText += source;
             }

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -266,7 +266,7 @@ define([
 
             // Wraps the text based and the width and height that were set for the
             // annotation
-            this.label = dc.textSupport.wrap(
+            this.label = dc.textRenderer.wrap(
                 this.label,
                 this.attributes.width, this.attributes.height,
                 this.attributes.textAttributes.font);
@@ -290,7 +290,7 @@ define([
             this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
 
             if (!this.labelTexture) {
-                this.labelTexture = dc.textSupport.createTexture(dc, this.label, labelFont, false);
+                this.labelTexture = dc.textRenderer.createTexture(dc, this.label, labelFont, false);
                 dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
             }
 

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -532,12 +532,12 @@ define([
                 return dc.pickRectangle && (this.imageBounds.intersects(dc.pickRectangle)
                     || (this.mustDrawLabel() && this.labelBounds.intersects(dc.pickRectangle))
                     || (this.mustDrawLeaderLine(dc)
-                    && dc.pickFrustum.intersectsSegment(this.groundPoint, this.placePoint)));
+                        && dc.pickFrustum.intersectsSegment(this.groundPoint, this.placePoint)));
             } else {
                 return this.imageBounds.intersects(dc.navigatorState.viewport)
                     || (this.mustDrawLabel() && this.labelBounds.intersects(dc.navigatorState.viewport))
                     || (this.mustDrawLeaderLine(dc)
-                    && dc.navigatorState.frustumInModelCoordinates.intersectsSegment(this.groundPoint, this.placePoint));
+                        && dc.navigatorState.frustumInModelCoordinates.intersectsSegment(this.groundPoint, this.placePoint));
             }
         };
 
@@ -714,7 +714,7 @@ define([
             // Perform the tilt before applying the rotation so that the image tilts back from its base into
             // the view volume.
             var actualTilt = this.imageTiltReference === WorldWind.RELATIVE_TO_GLOBE ?
-            dc.navigatorState.tilt + this.imageTilt : this.imageTilt;
+                dc.navigatorState.tilt + this.imageTilt : this.imageTilt;
             Placemark.matrix.multiplyByRotation(-1, 0, 0, actualTilt);
 
             program.loadModelviewProjection(gl, Placemark.matrix);

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -485,7 +485,7 @@ define([
 
                 this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
                 if (!this.labelTexture) {
-                    this.labelTexture = dc.textSupport.createTexture(dc, this.label, labelFont, true);
+                    this.labelTexture = dc.textRenderer.createTexture(dc, this.label, labelFont, true);
                     dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
                 }
 

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -317,7 +317,7 @@ define([
 
             this.activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!this.activeTexture) {
-                this.activeTexture = dc.textSupport.createTexture(dc, this.text, labelFont, true);
+                this.activeTexture = dc.textRenderer.createTexture(dc, this.text, labelFont, true);
                 dc.gpuResourceCache.putResource(textureKey, this.activeTexture, this.activeTexture.size);
             }
 


### PR DESCRIPTION
Renamed TextSupport class and its instances as TextRenderer to make the semantics of the migration easier to talk about. Related to #176.