### PR TITLE
Refactor of TextRenderer properties and its createTexture function

### DIFF
--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -148,7 +148,7 @@ define([
              * A shared TextRenderer instance.
              * @type {TextRenderer}
              */
-            this.textRenderer = new TextRenderer();
+            this.textRenderer = new TextRenderer(this);
 
             /**
              * The current WebGL framebuffer. Null indicates that the default WebGL framebuffer is active.

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -264,7 +264,7 @@ define([
             textureKey = credit.text + this.creditFont.toString();
             activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!activeTexture) {
-                activeTexture = dc.textRenderer.createTexture(dc, credit.text, this.creditFont, false);
+                activeTexture = dc.textRenderer.createTexture(credit.text);
                 dc.gpuResourceCache.putResource(textureKey, activeTexture, activeTexture.size);
             }
 

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -264,7 +264,7 @@ define([
             textureKey = credit.text + this.creditFont.toString();
             activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!activeTexture) {
-                activeTexture = dc.textRenderer.createTexture(credit.text);
+                activeTexture = dc.textRenderer.renderText(credit.text);
                 dc.gpuResourceCache.putResource(textureKey, activeTexture, activeTexture.size);
             }
 

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -113,7 +113,7 @@ define([
          * @param {String} text The text string.
          * @returns {Texture} A texture for the specified text string and font.
          */
-        TextRenderer.prototype.createTexture = function (text) {
+        TextRenderer.prototype.renderText = function (text) {
             var ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
                 textSize = this.textSize(text, this.typeFace, this.enableOutline),

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -114,7 +114,7 @@ define([
          * @returns {Texture} A texture for the specified text string.
          */
         TextRenderer.prototype.renderText = function (text) {
-            if (text !== null && text.length > 0) {
+            if (text && text.length > 0) {
                 var canvas2D = this.drawText(text);
                 return new Texture(this.dc.currentGlContext, canvas2D)
             } else {

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -29,6 +29,7 @@ define([
     function (ArgumentError,
               BasicTextureProgram,
               Color,
+              Font,
               Logger,
               Matrix,
               Texture,

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -20,6 +20,7 @@ define([
         '../error/ArgumentError',
         '../shaders/BasicTextureProgram',
         '../util/Color',
+        '../util/Font',
         '../util/Logger',
         '../geom/Matrix',
         '../render/Texture',
@@ -42,13 +43,17 @@ define([
          * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically do
          * not create instances of this class.
          */
-        var TextRenderer = function () {
+        var TextRenderer = function (dc) {
 
             // Internal use only. Intentionally not documented.
             this.canvas2D = document.createElement("canvas");
 
             // Internal use only. Intentionally not documented.
             this.ctx2D = this.canvas2D.getContext("2d");
+
+            this.drawContext = dc;
+
+            this.enableOutline = false;
 
             // Internal use only. Intentionally not documented.
             this.lineSpacing = 0.15; // fraction of font size
@@ -58,6 +63,8 @@ define([
 
             // Internal use only. Intentionally not documented.
             this.strokeWidth = 4;
+
+            this.typeFace = new Font(14);
         };
 
         /**

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -43,8 +43,15 @@ define([
          * @classdesc Provides methods useful for displaying text. An instance of this class is attached to the
          * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically do
          * not create instances of this class.
+         * @param {drawContext} drawContext The current draw context. Typically the same draw context that TextRenderer
+         * is attached to.
+         * @throws {ArgumentError} If the specified draw context is null or undefined.
          */
-        var TextRenderer = function (dc) {
+        var TextRenderer = function (drawContext) {
+            if (!drawContext) {
+                throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "TextRenderer", "constructor",
+                    "missingDrawContext"));
+            }
 
             // Internal use only. Intentionally not documented.
             this.canvas2D = document.createElement("canvas");
@@ -52,8 +59,10 @@ define([
             // Internal use only. Intentionally not documented.
             this.ctx2D = this.canvas2D.getContext("2d");
 
-            this.dc = dc;
+            // Internal use only. Intentionally not documented.
+            this.dc = drawContext;
 
+            // Internal use only. Intentionally not documented.
             this.enableOutline = false;
 
             // Internal use only. Intentionally not documented.
@@ -65,6 +74,7 @@ define([
             // Internal use only. Intentionally not documented.
             this.strokeWidth = 4;
 
+            // Internal use only. Intentionally not documented.
             this.typeFace = new Font(14);
         };
 
@@ -99,15 +109,12 @@ define([
         };
 
         /**
-         * Creates a texture for a specified text string, a specified font and an optional outline.
+         * Creates a texture for a specified text string.
          * @param {String} text The text string.
-         * @param {Font} font The font to use.
-         * @param {Boolean} outline Indicates whether the text is drawn with a thin black outline.
          * @returns {Texture} A texture for the specified text string and font.
          */
         TextRenderer.prototype.createTexture = function (text) {
-            var gl = this.dc.currentGlContext,
-                ctx2D = this.ctx2D,
+            var ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
                 textSize = this.textSize(text, this.typeFace, this.enableOutline),
                 lines = text.split("\n"),
@@ -144,7 +151,7 @@ define([
                 ctx2D.translate(0, this.typeFace.size * (1 + this.lineSpacing) + strokeOffset);
             }
 
-            return new Texture(gl, canvas2D);
+            return new Texture(this.dc.currentGlContext, canvas2D);
         };
 
         /**

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -104,13 +104,13 @@ define([
          * @param {Boolean} outline Indicates whether the text is drawn with a thin black outline.
          * @returns {Texture} A texture for the specified text string and font.
          */
-        TextRenderer.prototype.createTexture = function (text, font, outline) {
+        TextRenderer.prototype.createTexture = function (text) {
             var gl = this.dc.currentGlContext,
                 ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
-                textSize = this.textSize(text, font, outline),
+                textSize = this.textSize(text, this.typeFace, this.enableOutline),
                 lines = text.split("\n"),
-                strokeOffset = outline ? this.strokeWidth / 2 : 0,
+                strokeOffset = this.enableOutline ? this.strokeWidth / 2 : 0,
                 pixelScale = this.dc.pixelScale,
                 x, y;
 
@@ -118,29 +118,29 @@ define([
             canvas2D.height = Math.ceil(textSize[1]) * pixelScale;
 
             ctx2D.scale(pixelScale, pixelScale);
-            ctx2D.font = font.fontString;
+            ctx2D.font = this.typeFace.fontString;
             ctx2D.textBaseline = "top";
-            ctx2D.textAlign = font.horizontalAlignment;
+            ctx2D.textAlign = this.typeFace.horizontalAlignment;
             ctx2D.fillStyle = Color.WHITE.toHexString(false);
             ctx2D.strokeStyle = this.strokeStyle;
             ctx2D.lineWidth = this.strokeWidth;
             ctx2D.lineCap = "round";
             ctx2D.lineJoin = "round";
 
-            if (font.horizontalAlignment === "left") {
+            if (this.typeFace.horizontalAlignment === "left") {
                 ctx2D.translate(strokeOffset, 0);
-            } else if (font.horizontalAlignment === "right") {
+            } else if (this.typeFace.horizontalAlignment === "right") {
                 ctx2D.translate(textSize[0] - strokeOffset, 0);
             } else {
                 ctx2D.translate(textSize[0] / 2, 0);
             }
 
             for (var i = 0; i < lines.length; i++) {
-                if (outline) {
+                if (this.enableOutline) {
                     ctx2D.strokeText(lines[i], 0, 0);
                 }
                 ctx2D.fillText(lines[i], 0, 0);
-                ctx2D.translate(0, font.size * (1 + this.lineSpacing) + strokeOffset);
+                ctx2D.translate(0, this.typeFace.size * (1 + this.lineSpacing) + strokeOffset);
             }
 
             return new Texture(gl, canvas2D);

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -51,7 +51,7 @@ define([
             // Internal use only. Intentionally not documented.
             this.ctx2D = this.canvas2D.getContext("2d");
 
-            this.drawContext = dc;
+            this.dc = dc;
 
             this.enableOutline = false;
 
@@ -99,20 +99,19 @@ define([
 
         /**
          * Creates a texture for a specified text string, a specified font and an optional outline.
-         * @param {DrawContext} dc The current draw context.
          * @param {String} text The text string.
          * @param {Font} font The font to use.
          * @param {Boolean} outline Indicates whether the text is drawn with a thin black outline.
          * @returns {Texture} A texture for the specified text string and font.
          */
-        TextRenderer.prototype.createTexture = function (dc, text, font, outline) {
-            var gl = dc.currentGlContext,
+        TextRenderer.prototype.createTexture = function (text, font, outline) {
+            var gl = this.dc.currentGlContext,
                 ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
                 textSize = this.textSize(text, font, outline),
                 lines = text.split("\n"),
                 strokeOffset = outline ? this.strokeWidth / 2 : 0,
-                pixelScale = dc.pixelScale,
+                pixelScale = this.dc.pixelScale,
                 x, y;
 
             canvas2D.width = Math.ceil(textSize[0]) * pixelScale;

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -63,7 +63,7 @@ define([
             this.dc = drawContext;
 
             // Internal use only. Intentionally not documented.
-            this.enableOutline = false;
+            this.enableOutline = true;
 
             // Internal use only. Intentionally not documented.
             this.lineSpacing = 0.15; // fraction of font size

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -111,9 +111,23 @@ define([
         /**
          * Creates a texture for a specified text string.
          * @param {String} text The text string.
-         * @returns {Texture} A texture for the specified text string and font.
+         * @returns {Texture} A texture for the specified text string.
          */
         TextRenderer.prototype.renderText = function (text) {
+            if (text !== null && text.length > 0) {
+                var canvas2D = this.drawText(text);
+                return new Texture(this.dc.currentGlContext, canvas2D)
+            } else {
+                return null;
+            }
+        };
+
+        /**
+         * Creates a 2D Canvas for a specified text string.
+         * @param {String} text The text string.
+         * @returns {canvas2D} A 2D Canvas for the specified text string.
+         */
+        TextRenderer.prototype.drawText = function (text) {
             var ctx2D = this.ctx2D,
                 canvas2D = this.canvas2D,
                 textSize = this.textSize(text, this.typeFace, this.enableOutline),
@@ -151,7 +165,7 @@ define([
                 ctx2D.translate(0, this.typeFace.size * (1 + this.lineSpacing) + strokeOffset);
             }
 
-            return new Texture(this.dc.currentGlContext, canvas2D);
+            return canvas2D;
         };
 
         /**

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -290,7 +290,7 @@ define([
             this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
 
             if (!this.labelTexture) {
-                this.labelTexture = dc.textRenderer.createTexture(dc, this.label, labelFont, false);
+                this.labelTexture = dc.textRenderer.createTexture(this.label);
                 dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
             }
 

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -290,7 +290,9 @@ define([
             this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
 
             if (!this.labelTexture) {
+                dc.textRenderer.enableOutline = false; // Temporary, while TextRenderer is refactored
                 this.labelTexture = dc.textRenderer.renderText(this.label);
+                dc.textRenderer.enableOutline = true; // Temporary, while TextRenderer is refactored
                 dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
             }
 

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -290,7 +290,7 @@ define([
             this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
 
             if (!this.labelTexture) {
-                this.labelTexture = dc.textRenderer.createTexture(this.label);
+                this.labelTexture = dc.textRenderer.renderText(this.label);
                 dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
             }
 

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -485,7 +485,7 @@ define([
 
                 this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
                 if (!this.labelTexture) {
-                    this.labelTexture = dc.textRenderer.createTexture(dc, this.label, labelFont, true);
+                    this.labelTexture = dc.textRenderer.createTexture(this.label);
                     dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
                 }
 

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -485,7 +485,7 @@ define([
 
                 this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
                 if (!this.labelTexture) {
-                    this.labelTexture = dc.textRenderer.createTexture(this.label);
+                    this.labelTexture = dc.textRenderer.renderText(this.label);
                     dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
                 }
 

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -317,7 +317,7 @@ define([
 
             this.activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!this.activeTexture) {
-                this.activeTexture = dc.textRenderer.createTexture(dc, this.text, labelFont, true);
+                this.activeTexture = dc.textRenderer.createTexture(this.text);
                 dc.gpuResourceCache.putResource(textureKey, this.activeTexture, this.activeTexture.size);
             }
 

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -317,7 +317,7 @@ define([
 
             this.activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!this.activeTexture) {
-                this.activeTexture = dc.textRenderer.createTexture(this.text);
+                this.activeTexture = dc.textRenderer.renderText(this.text);
                 dc.gpuResourceCache.putResource(textureKey, this.activeTexture, this.activeTexture.size);
             }
 

--- a/test/render/TextRenderer.test.js
+++ b/test/render/TextRenderer.test.js
@@ -23,7 +23,7 @@ define([
         var testText = "Lorem ipsum dolor sit amet, consectetur "
             + "adipiscing elit, sed do eiusmod tempor incididunt ut";
 
-        var dc = new DrawContext;
+        var mockDrawContext = new DrawContext;
         var myFont = new Font(15);
 
         it("Should throw an exception on missing constructor draw context", function () {
@@ -34,25 +34,25 @@ define([
 
         it("Should throw an exception on missing text input", function () {
             expect(function () {
-                var mockTextRenderer = new TextRenderer(dc);
+                var mockTextRenderer = new TextRenderer(mockDrawContext);
                 mockTextRenderer.wrap(null, 20, 100, myFont);
             }).toThrow();
         });
 
         it("Should output '...' due to wrap height being less than textSize height", function () {
-            var mockTextRenderer = new TextRenderer(dc);
+            var mockTextRenderer = new TextRenderer(mockDrawContext);
             var wrappedText = mockTextRenderer.wrap(testText, 92, 15, myFont);
             expect(wrappedText).toEqual("...");
         });
 
         it("Should output 'Lorem ipsum...' due to wrap width being less than textSize width", function () {
-            var mockTextRenderer = new TextRenderer(dc);
+            var mockTextRenderer = new TextRenderer(mockDrawContext);
             var wrappedText = mockTextRenderer.wrap(testText, 90, 16, myFont);
             expect(wrappedText).toEqual("Lorem ipsum...");
         });
 
         it("Should output every word on testText in different lines", function () {
-            var mockTextRenderer = new TextRenderer(dc);
+            var mockTextRenderer = new TextRenderer(mockDrawContext);
             // Wrap line width less than textSize texture width
             var wrappedLines = mockTextRenderer.wrapLine(testText, 0, myFont);
             expect(wrappedLines).toEqual("Lorem\n" +

--- a/test/render/TextRenderer.test.js
+++ b/test/render/TextRenderer.test.js
@@ -13,32 +13,46 @@ define([
             return new Vec2(text.length * 7, 16);
         };
 
+        // Mocking draw context to avoid WebGL requirements.
+        var DrawContext = function () {
+            this.currentGlContext = "fake GL context";
+            this.pixelScale = 1;
+            this.textRenderer = new TextRenderer(this);
+        }
+        
         var testText = "Lorem ipsum dolor sit amet, consectetur "
             + "adipiscing elit, sed do eiusmod tempor incididunt ut";
 
+        var dc = new DrawContext;
         var myFont = new Font(15);
+
+        it("Should throw an exception on missing constructor draw context", function () {
+            expect(function () {
+                var mockTextRenderer = new TextRenderer(null);
+            }).toThrow();
+        });
 
         it("Should throw an exception on missing text input", function () {
             expect(function () {
-                var mockTextRenderer = new TextRenderer();
+                var mockTextRenderer = new TextRenderer(dc);
                 mockTextRenderer.wrap(null, 20, 100, myFont);
             }).toThrow();
         });
 
         it("Should output '...' due to wrap height being less than textSize height", function () {
-            var mockTextRenderer = new TextRenderer();
+            var mockTextRenderer = new TextRenderer(dc);
             var wrappedText = mockTextRenderer.wrap(testText, 92, 15, myFont);
             expect(wrappedText).toEqual("...");
         });
 
         it("Should output 'Lorem ipsum...' due to wrap width being less than textSize width", function () {
-            var mockTextRenderer = new TextRenderer();
+            var mockTextRenderer = new TextRenderer(dc);
             var wrappedText = mockTextRenderer.wrap(testText, 90, 16, myFont);
             expect(wrappedText).toEqual("Lorem ipsum...");
         });
 
         it("Should output every word on testText in different lines", function () {
-            var mockTextRenderer = new TextRenderer();
+            var mockTextRenderer = new TextRenderer(dc);
             // Wrap line width less than textSize texture width
             var wrappedLines = mockTextRenderer.wrapLine(testText, 0, myFont);
             expect(wrappedLines).toEqual("Lorem\n" +

--- a/test/render/TextRenderer.test.js
+++ b/test/render/TextRenderer.test.js
@@ -19,7 +19,7 @@ define([
             this.pixelScale = 1;
             this.textRenderer = new TextRenderer(this);
         }
-        
+
         var testText = "Lorem ipsum dolor sit amet, consectetur "
             + "adipiscing elit, sed do eiusmod tempor incididunt ut";
 
@@ -30,6 +30,11 @@ define([
             expect(function () {
                 var mockTextRenderer = new TextRenderer(null);
             }).toThrow();
+        });
+
+        it("Should return null due to empty string input on RenderText", function () {
+            var mockTextRenderer = new TextRenderer(mockDrawContext);
+            expect(mockTextRenderer.renderText("")).toBeNull();
         });
 
         it("Should throw an exception on missing text input", function () {


### PR DESCRIPTION
### Description of the Change
Modified TextRenderer to begin refactoring as an analogue of WorldWind Android's version. This change was focused on adding new properties to the class and modifying the createTexture function. Future refactors to other functions will follow.

TextRenderer unit test was also modified to reflect the changes in its constructor, and a new test was added.

### Why Should This Be In Core?
This is a start on having Web WorldWind's and WorldWind Android's TextRenderer aligned between each other. It's also intended to be the first step on enabling text outlining color customization, as mentioned in issue #173.

### Benefits
Brings TextRenderer closer in terms of design between the Android and web version.

### Potential Drawbacks
- As it is now, every rendered piece of text has no outline by default (for Annotations, Placemarks, ScreenText, screen credits, etc). This could affect reading clarity depending on the imagery that's visualized in the globe, although the idea of course is to immediately revisit the outlining features after this PR.

- The TextRenderer requires a whole DrawContext to be fed to it. (This was also the case before this refactor), while only DrawContext.currentGlContext and DrawContext.pixelScale are used inside TextRenderer. Maybe limiting the consumption to this two properties instead of the whole object would be a better fit?

### Applicable Issues
Partially addresses #176 