### PR TITLE
Addition of text outline color customization features

### DIFF
--- a/examples/Annotations.js
+++ b/examples/Annotations.js
@@ -51,7 +51,6 @@ requirejs(['./WorldWindShim',
         annotationAttributes.width = 200;
         annotationAttributes.height = 100;
         annotationAttributes.textAttributes.color = WorldWind.Color.WHITE;
-        annotationAttributes.textAttributes.enableOutline = false;
         annotationAttributes.insets = new WorldWind.Insets(10, 10, 10, 10);
 
         // Set a location for the annotation to point to and create it.

--- a/examples/Annotations.js
+++ b/examples/Annotations.js
@@ -51,6 +51,7 @@ requirejs(['./WorldWindShim',
         annotationAttributes.width = 200;
         annotationAttributes.height = 100;
         annotationAttributes.textAttributes.color = WorldWind.Color.WHITE;
+        annotationAttributes.textAttributes.enableOutline = false;
         annotationAttributes.insets = new WorldWind.Insets(10, 10, 10, 10);
 
         // Set a location for the annotation to point to and create it.

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1517,5 +1517,19 @@ define([
             return this.pixelSizeFactor * distance + this.pixelSizeOffset;
         };
 
+        DrawContext.prototype.renderText = function (text, textAttributes) {
+
+            if (text != null && textAttributes != null) {
+                this.textRenderer.textColor = textAttributes.color.get();
+                this.textRenderer.typeFace = textAttributes.font.get();
+                this.textRenderer.enableOutline = textAttributes.enableOutline.get();
+                this.textRenderer.outlineColor = textAttributes.outlineColor.get();
+                this.textRenderer.outlineWidth = textAttributes.outlineWidth.get();
+                var texture = this.textRenderer.renderText(text);
+            }
+
+            return texture;
+        };
+
         return DrawContext;
     });

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1517,6 +1517,17 @@ define([
             return this.pixelSizeFactor * distance + this.pixelSizeOffset;
         };
 
+        /**
+         * Propagates the values contained in a TextAttributes object to the currently attached TextRenderer
+         * {@link TextRenderer} as to provide format to a string of text. The TextRenderer then produces a
+         * 2D Texture with the aforementioned text and format to be used as a label for a Text {@link Text}
+         * subclass (<i>e.g.</i> Annotation {@link Annotation} or Placemark {@link Placemark}).
+         * @param {String} text The string of text that will be given color, font, and outline
+         * and which the resulting texture will be based on.
+         * @param {TextAttributes} textAttributes Attributes that will be applied to the string.
+         * See TextAttributes {@link TextAttributes}.
+         * @returns {Texture} A texture {@link Texture} with the specified text string, typeface, colors, and outline.
+         */
         DrawContext.prototype.renderText = function (text, textAttributes) {
 
             var texture = null;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1519,13 +1519,15 @@ define([
 
         DrawContext.prototype.renderText = function (text, textAttributes) {
 
+            var texture = null;
+
             if (text != null && textAttributes != null) {
-                this.textRenderer.textColor = textAttributes.color.get();
-                this.textRenderer.typeFace = textAttributes.font.get();
-                this.textRenderer.enableOutline = textAttributes.enableOutline.get();
-                this.textRenderer.outlineColor = textAttributes.outlineColor.get();
-                this.textRenderer.outlineWidth = textAttributes.outlineWidth.get();
-                var texture = this.textRenderer.renderText(text);
+                this.textRenderer.textColor = textAttributes.color;
+                this.textRenderer.typeFace = textAttributes.font;
+                this.textRenderer.enableOutline = textAttributes.enableOutline;
+                this.textRenderer.outlineColor = textAttributes.outlineColor;
+                this.textRenderer.outlineWidth = textAttributes.outlineWidth;
+                texture = this.textRenderer.renderText(text);
             }
 
             return texture;

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -62,22 +62,38 @@ define([
             // Internal use only. Intentionally not documented.
             this.dc = drawContext;
 
-            // Internal use only. Intentionally not documented.
+            /**
+             * Indicates if the text will feature an outline around its characters.
+             * @type {boolean}
+             */
             this.enableOutline = true;
 
             // Internal use only. Intentionally not documented.
             this.lineSpacing = 0.15; // fraction of font size
 
-            // Internal use only. Intentionally not documented.
+            /**
+             * The color for the Text outline.
+             * Its default has half transparency to avoid visual artifacts that appear while fully opaque.
+             * @type {Color}
+             */
             this.outlineColor = new Color(0, 0, 0, 0.5);
 
-            // Internal use only. Intentionally not documented.
+            /**
+             * Indicates the text outline width (or thickness) in pixels.
+             * @type {number}
+             */
             this.outlineWidth = 4;
 
-            // Internal use only. Intentionally not documented.
+            /**
+             * The text color.
+             * @type {Color}
+             */
             this.textColor = new Color(1, 1, 1, 1);
 
-            // Internal use only. Intentionally not documented.
+            /**
+             * The text size, face and other characteristics, as described in [Font]{@link Font}.
+             * @type {Font}
+             */
             this.typeFace = new Font(14);
         };
 
@@ -110,7 +126,7 @@ define([
         };
 
         /**
-         * Creates a texture for a specified text string.
+         * Creates a texture for a specified text string and current TextRenderer state.
          * @param {String} text The text string.
          * @returns {Texture} A texture for the specified text string.
          */
@@ -124,7 +140,8 @@ define([
         };
 
         /**
-         * Creates a 2D Canvas for a specified text string.
+         * Creates a 2D Canvas for a specified text string while considering current TextRenderer state in
+         * regards to outline usage and color, text color, typeface, and outline width.
          * @param {String} text The text string.
          * @returns {canvas2D} A 2D Canvas for the specified text string.
          */

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -41,8 +41,8 @@ define([
          * @alias TextRenderer
          * @constructor
          * @classdesc Provides methods useful for displaying text. An instance of this class is attached to the
-         * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically
-         * do not create instances of this class.
+         * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically do
+         * not create instances of this class.
          * @param {drawContext} drawContext The current draw context. Typically the same draw context that TextRenderer
          * is attached to.
          * @throws {ArgumentError} If the specified draw context is null or undefined.

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -82,7 +82,7 @@ define([
         };
 
         /**
-         * Returns the width and height of a specified text string.
+         * Returns the width and height of a specified text string considering the current typeFace and outline usage.
          * @param {string} text The text string.
          * @returns {Vec2} A vector indicating the text's width and height, respectively, in pixels.
          */
@@ -169,6 +169,15 @@ define([
         };
 
         /**
+         * Calculates maximum line height based on the current typeFace and outline usage of TextRenderer.
+         * @returns {Vec2} A vector indicating the text's width and height, respectively, in pixels.
+         */
+        TextRenderer.prototype.getMaxLineHeight = function () {
+            // Check underscore + capital E with acute accent
+            return this.textSize("_\u00c9")[1];
+        };
+
+        /**
          * Wraps the text based on width and height using new line delimiter
          * @param {String} text The text to wrap.
          * @param {Number} width The width in pixels.
@@ -195,7 +204,7 @@ define([
             // Checks for height limit.
             var currentHeight = 0;
             var heightExceeded = false;
-            var maxLineHeight = this.textSize("_\u00c9")[1]; // Check underscore + capital E with acute accent
+            var maxLineHeight = this.getMaxLineHeight();
             for (i = 0; i < lines.length && !heightExceeded; i++) {
                 var subLines = lines[i].split("\n");
                 for (var j = 0; j < subLines.length && !heightExceeded; j++) {

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -41,8 +41,8 @@ define([
          * @alias TextRenderer
          * @constructor
          * @classdesc Provides methods useful for displaying text. An instance of this class is attached to the
-         * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically do
-         * not create instances of this class.
+         * WorldWindow {@link DrawContext} and is not intended to be used independently of that. Applications typically
+         * do not create instances of this class.
          * @param {drawContext} drawContext The current draw context. Typically the same draw context that TextRenderer
          * is attached to.
          * @throws {ArgumentError} If the specified draw context is null or undefined.
@@ -50,7 +50,7 @@ define([
         var TextRenderer = function (drawContext) {
             if (!drawContext) {
                 throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "TextRenderer", "constructor",
-                    "missingDrawContext"));
+                    "missingDc"));
             }
 
             // Internal use only. Intentionally not documented.
@@ -119,7 +119,7 @@ define([
         TextRenderer.prototype.renderText = function (text) {
             if (text && text.length > 0) {
                 var canvas2D = this.drawText(text);
-                return new Texture(this.dc.currentGlContext, canvas2D)
+                return new Texture(this.dc.currentGlContext, canvas2D);
             } else {
                 return null;
             }

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -268,8 +268,7 @@ define([
             // annotation
             this.label = dc.textRenderer.wrap(
                 this.label,
-                this.attributes.width, this.attributes.height,
-                this.attributes.textAttributes.font);
+                this.attributes.width, this.attributes.height);
 
             // Compute the annotation's model point.
             dc.surfacePointForMode(this.position.latitude, this.position.longitude, this.position.altitude,

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -289,9 +289,7 @@ define([
             this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
 
             if (!this.labelTexture) {
-                dc.textRenderer.enableOutline = false; // Temporary, while TextRenderer is refactored
-                this.labelTexture = dc.textRenderer.renderText(this.label);
-                dc.textRenderer.enableOutline = true; // Temporary, while TextRenderer is refactored
+                this.labelTexture = dc.renderText(this.label, this.attributes.textAttributes);
                 dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
             }
 

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -520,7 +520,7 @@ define([
             Annotation.matrix.multiplyByTextureTransform(this.labelTexture);
             program.loadTextureMatrix(gl, Annotation.matrix);
 
-            program.loadColor(gl, dc.pickingMode ? this.pickColor : this.attributes.textAttributes.color);
+            program.loadColor(gl, dc.pickingMode ? this.pickColor : Color.WHITE);
             textureBound = this.labelTexture.bind(dc);
             program.loadTextureEnabled(gl, textureBound);
 

--- a/src/shapes/AnnotationAttributes.js
+++ b/src/shapes/AnnotationAttributes.js
@@ -46,7 +46,11 @@ define([
             this._drawLeader = attributes ? attributes._drawLeader : true;
             this._width = attributes ? attributes._width : 200;
             this._height = attributes ? attributes._height : 100;
-            this._textAttributes = attributes ? attributes._textAttributes : new TextAttributes(null);
+
+            // Disabling the Annotation's text outline by default.
+            var defaultAttributes = new TextAttributes(null);
+            defaultAttributes.enableOutline = false;
+            this._textAttributes = attributes ? attributes._textAttributes : defaultAttributes;
 
             /**
              * Indicates whether this object's state key is invalid. Subclasses must set this value to true when their

--- a/src/shapes/AnnotationAttributes.js
+++ b/src/shapes/AnnotationAttributes.js
@@ -48,9 +48,10 @@ define([
             this._height = attributes ? attributes._height : 100;
 
             // Disabling the Annotation's text outline by default.
-            var defaultAttributes = new TextAttributes(null);
-            defaultAttributes.enableOutline = false;
-            this._textAttributes = attributes ? attributes._textAttributes : defaultAttributes;
+            var defaultTextAttributes = new TextAttributes(null);
+            defaultTextAttributes.enableOutline = false;
+
+            this._textAttributes = attributes ? attributes._textAttributes : defaultTextAttributes;
 
             /**
              * Indicates whether this object's state key is invalid. Subclasses must set this value to true when their

--- a/src/shapes/AnnotationAttributes.js
+++ b/src/shapes/AnnotationAttributes.js
@@ -46,12 +46,7 @@ define([
             this._drawLeader = attributes ? attributes._drawLeader : true;
             this._width = attributes ? attributes._width : 200;
             this._height = attributes ? attributes._height : 100;
-
-            // Disabling the Annotation's text outline by default.
-            var defaultTextAttributes = new TextAttributes(null);
-            defaultTextAttributes.enableOutline = false;
-
-            this._textAttributes = attributes ? attributes._textAttributes : defaultTextAttributes;
+            this._textAttributes = attributes ? attributes._textAttributes : this.createDefaultTextAttributes();
 
             /**
              * Indicates whether this object's state key is invalid. Subclasses must set this value to true when their
@@ -82,6 +77,13 @@ define([
                 + " op " + this.opacity
                 + " ta " + this._textAttributes.stateKey
                 + " sc " + this.scale;
+        };
+
+        // Internal use only. Intentionally not documented.
+        AnnotationAttributes.prototype.createDefaultTextAttributes = function() {
+            var attributes = new TextAttributes(null);
+            attributes.enableOutline = false; // Annotations display text without an outline by default
+            return attributes;
         };
 
         Object.defineProperties(AnnotationAttributes.prototype, {

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -485,7 +485,7 @@ define([
 
                 this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
                 if (!this.labelTexture) {
-                    this.labelTexture = dc.textRenderer.renderText(this.label);
+                    this.labelTexture = dc.renderText(this.label, this.activeAttributes.labelAttributes);
                     dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
                 }
 
@@ -758,7 +758,7 @@ define([
                     this.texCoordMatrix.multiplyByTextureTransform(this.labelTexture);
 
                     program.loadTextureMatrix(gl, this.texCoordMatrix);
-                    program.loadColor(gl, this.activeAttributes.labelAttributes.color);
+                    program.loadColor(gl, Color.WHITE);
 
                     textureBound = this.labelTexture.bind(dc);
                     program.loadTextureEnabled(gl, textureBound);

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -317,7 +317,7 @@ define([
 
             this.activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
             if (!this.activeTexture) {
-                this.activeTexture = dc.textRenderer.renderText(this.text);
+                this.activeTexture = dc.renderText(this.text, this.activeAttributes);
                 dc.gpuResourceCache.putResource(textureKey, this.activeTexture, this.activeTexture.size);
             }
 

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -468,7 +468,8 @@ define([
                 gl.disable(gl.DEPTH_TEST);
             }
 
-            // Use the text color and opacity. When picking, use the pick color, 100% opacity and no texture.
+            // Use the text color and opacity. Modulation is done to white to avoid the program's shader from
+            // modifying the text color. When picking, use the pick color, 100% opacity and no texture.
             if (!dc.pickingMode) {
                 program.loadColor(gl, Color.WHITE);
                 program.loadOpacity(gl, this.layer.opacity * this.currentVisibility);

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -255,7 +255,7 @@ define([
             // Create an ordered renderable for this text. If one has already been created this frame then we're
             // in 2D-continuous mode and another needs to be created for one of the alternate globe offsets.
             var orderedText;
-            if (this.lastFrameTime != dc.timestamp) {
+            if (this.lastFrameTime !== dc.timestamp) {
                 orderedText = this.makeOrderedRenderable(dc);
             } else {
                 var textCopy = this.clone();
@@ -470,7 +470,7 @@ define([
 
             // Use the text color and opacity. When picking, use the pick color, 100% opacity and no texture.
             if (!dc.pickingMode) {
-                program.loadColor(gl, this.activeAttributes.color);
+                program.loadColor(gl, Color.WHITE);
                 program.loadOpacity(gl, this.layer.opacity * this.currentVisibility);
             } else {
                 this.pickColor = dc.uniquePickColor();

--- a/src/shapes/TextAttributes.js
+++ b/src/shapes/TextAttributes.js
@@ -71,7 +71,7 @@ define([
                 " dt " + this._depthTest +
                 " eo " + this._enableOutline +
                 " ow " + this._outlineWidth +
-                " oc " + this._outlineColor;
+                " oc " + this._outlineColor.toHexString(true);
         };
 
         Object.defineProperties(TextAttributes.prototype, {

--- a/src/shapes/TextAttributes.js
+++ b/src/shapes/TextAttributes.js
@@ -44,7 +44,7 @@ define([
             this._depthTest = attributes ? attributes._depthTest : false;
             this._enableOutline = attributes ? attributes._enableOutline : true;
             this._outlineWidth = attributes ? attributes._outlineWidth : 4;
-            this._outlineColor = attributes ? attributes._color : new Color(0, 0, 0, 0.5);
+            this._outlineColor = attributes ? attributes._outlineColor : new Color(0, 0, 0, 0.5);
 
             /**
              * Indicates whether this object's state key is invalid. Subclasses must set this value to true when their

--- a/test/render/TextRenderer.test.js
+++ b/test/render/TextRenderer.test.js
@@ -24,7 +24,6 @@ define([
             + "adipiscing elit, sed do eiusmod tempor incididunt ut";
 
         var mockDrawContext = new DrawContext;
-        var myFont = new Font(15);
 
         it("Should throw an exception on missing constructor draw context", function () {
             expect(function () {
@@ -40,26 +39,26 @@ define([
         it("Should throw an exception on missing text input", function () {
             expect(function () {
                 var mockTextRenderer = new TextRenderer(mockDrawContext);
-                mockTextRenderer.wrap(null, 20, 100, myFont);
+                mockTextRenderer.wrap(null, 20, 100);
             }).toThrow();
         });
 
         it("Should output '...' due to wrap height being less than textSize height", function () {
             var mockTextRenderer = new TextRenderer(mockDrawContext);
-            var wrappedText = mockTextRenderer.wrap(testText, 92, 15, myFont);
+            var wrappedText = mockTextRenderer.wrap(testText, 92, 15);
             expect(wrappedText).toEqual("...");
         });
 
         it("Should output 'Lorem ipsum...' due to wrap width being less than textSize width", function () {
             var mockTextRenderer = new TextRenderer(mockDrawContext);
-            var wrappedText = mockTextRenderer.wrap(testText, 90, 16, myFont);
+            var wrappedText = mockTextRenderer.wrap(testText, 90, 16);
             expect(wrappedText).toEqual("Lorem ipsum...");
         });
 
         it("Should output every word on testText in different lines", function () {
             var mockTextRenderer = new TextRenderer(mockDrawContext);
             // Wrap line width less than textSize texture width
-            var wrappedLines = mockTextRenderer.wrapLine(testText, 0, myFont);
+            var wrappedLines = mockTextRenderer.wrapLine(testText, 0);
             expect(wrappedLines).toEqual("Lorem\n" +
                 "ipsum\n" +
                 "dolor\n" +


### PR DESCRIPTION
### Description of the Change
- Enabled the propagation of TextAttributes' values to the DrawContext's TextRenderer through a new `renderText()` function in DrawContext, similar to the homonymous function in WorldWind Android's RenderContext.
- Changed previous method of providing color to 2D text via grayscale texture modulation in order to maintain outline and fill colors as desired in Text and its subclasses (Annotation, Placemark and ScreenText).
- Finalizes details on TextRenderer refactor, as mentioned in issue #176.
- Modifies TextRenderer's unit tests to fit final design for this class.

Various corrections and fixes were addressed as well:
- Wrong logger message call in TextRenderer.
- Missing conversion to string in outline color state key of TextAttributes.
- Wrong assignment of `_color` instead of `_outlineColor` in TextAttributes.
- Corrected potential type coercion in comparison operator in Text.

### Why Should This Be In Core?
Adds new text outline color customization feature as originally requested in issue #97 while aligning text rendering features with those present in WorldWind Android.

### Benefits
Enables the display of the outline and fill text color as desired. Aligns text rendering design between WebWW and WWA.

### Potential Drawbacks
- We're losing the memory savings of using a grayscale texture to render text.
- ScreenCreditController is not modified to use these new text rendering facilities and still directly uses `dc.TextRenderer.renderText()`. This is due to this class' lack of usage of a TextAttributes object to define the text format.
- Text wrapping functions are still part of TextRenderer, somewhat separating WWA's and WebWW's design in this respect (WWA doesn't have text and line wrapping features).

### Applicable Issues
Closes #175
Closes #176 
 