### PR TITLE
Update tile with openstreetmap HOT tiles

### DIFF
--- a/src/layer/OpenStreetMapImageLayer.js
+++ b/src/layer/OpenStreetMapImageLayer.js
@@ -58,7 +58,7 @@ define([
             this.urlBuilder = {
                 urlForTile: function (tile, imageFormat) {
                     //var url = "https://a.tile.openstreetmap.org/" +
-                    return "https://otile1.mqcdn.com/tiles/1.0.0/osm/" +
+                    return "http://a.tile.openstreetmap.fr/hot/" +
                         (tile.level.levelNumber + 1) + "/" + tile.column + "/" + tile.row + ".png";
                 }
             };


### PR DESCRIPTION
Mapquest is not supported since 2016. Using this different tile the OSM layer works

**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change

### Why Should This Be In Core?

### Benefits

### Potential Drawbacks

### Applicable Issues