### PR TITLE
Fix WMTS TileMatrixSet selection

### DIFF
--- a/src/layer/WmtsLayer.js
+++ b/src/layer/WmtsLayer.js
@@ -481,7 +481,7 @@ define([
             // set negotiation.
             var supportedTileMatrixSets = wmtsLayerCapabilities.getLayerSupportedTileMatrixSets();
 
-            // Validate that the specified style identifier exists, or determine one if not specified.
+            // Validate that the specified TileMatrixSet exists and is compatible with WebWorldWind
             if (matrixSet) {
                 for (var i = 0, len = supportedTileMatrixSets.length; i < len; i++) {
                     if (supportedTileMatrixSets[i].identifier === matrixSet && WmtsLayer.isTileSubdivisionCompatible(supportedTileMatrixSets[i])) {

--- a/src/layer/WmtsLayer.js
+++ b/src/layer/WmtsLayer.js
@@ -158,6 +158,22 @@ define([
                         "No EPSG:4326 bounding box was specified in the layer or tile matrix set capabilities."));
             }
 
+            // Check if the provided TileMatrixSet level division is compatible
+            if (!WmtsLayer.checkTileSubdivision(this.tileMatrixSet)) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WmtsLayer", "constructor",
+                        "TileMatrixSet level division not compatible."));
+            }
+
+            // Check if the provided TileMatrixSet coordinate system is compatible
+            var crs = this.tileMatrixSet.supportedCRS;
+            var supportedCrs = WmtsLayer.isEpsg3857Crs(crs) || WmtsLayer.isEpsg4326Crs(crs) || WmtsLayer.isOGCCrs84(crs);
+            if (!supportedCrs) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WmtsLayer", "constructor",
+                        "Provided CRS is not compatible."));
+            }
+
             // Form a unique string to identify cache entries.
             this.cachePath = (this.resourceUrl || this.serviceUrl) +
                 this.layerIdentifier + this.styleIdentifier + this.tileMatrixSet.identifier;

--- a/src/layer/WmtsLayer.js
+++ b/src/layer/WmtsLayer.js
@@ -158,8 +158,8 @@ define([
                         "No EPSG:4326 bounding box was specified in the layer or tile matrix set capabilities."));
             }
 
-            // Check if the provided TileMatrixSet level division is compatible
-            if (!WmtsLayer.checkTileSubdivision(this.tileMatrixSet)) {
+            // Check if the provided TileMatrixSet tile subdivision is compatible
+            if (!WmtsLayer.isTileSubdivisionCompatible(this.tileMatrixSet)) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "WmtsLayer", "constructor",
                         "TileMatrixSet level division not compatible."));
@@ -206,10 +206,16 @@ define([
             this.detailControl = 1.75;
         };
 
-        WmtsLayer.checkTileSubdivision = function (tileMatrixSet) {
+        /**
+         * Determines if the tile subdivision of the provided TileMatrixSet is compatible with WebWorldWind.
+         * @param tileMatrixSet
+         * @returns {boolean} true if this tile subdivision will work with WebWorldWind
+         * @throws {ArgumentError} If the provided TileMatrixSet is null or empty
+         */
+        WmtsLayer.isTileSubdivisionCompatible = function (tileMatrixSet) {
             if (!tileMatrixSet || !tileMatrixSet.tileMatrix || tileMatrixSet.tileMatrix.length < 1) {
                 throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "WmtsLayer", "checkTileSubdivision",
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WmtsLayer", "isTileSubdivisionCompatible",
                         "Empty tile matrix set"));
             }
 
@@ -478,7 +484,7 @@ define([
             // Validate that the specified style identifier exists, or determine one if not specified.
             if (matrixSet) {
                 for (var i = 0, len = supportedTileMatrixSets.length; i < len; i++) {
-                    if (supportedTileMatrixSets[i].identifier === matrixSet && WmtsLayer.checkTileSubdivision(supportedTileMatrixSets[i])) {
+                    if (supportedTileMatrixSets[i].identifier === matrixSet && WmtsLayer.isTileSubdivisionCompatible(supportedTileMatrixSets[i])) {
                         config.tileMatrixSet = supportedTileMatrixSets[i];
                         break;
                     }
@@ -499,7 +505,7 @@ define([
                     tms = supportedTileMatrixSets[i];
 
                     // check for suitable tile division
-                    if (WmtsLayer.checkTileSubdivision(tms)) {
+                    if (WmtsLayer.isTileSubdivisionCompatible(tms)) {
                         if (WmtsLayer.isEpsg4326Crs(tms.supportedCRS)) {
                             tms4326 = tms4326 || tms;
                         } else if (WmtsLayer.isEpsg3857Crs(tms.supportedCRS)) {


### PR DESCRIPTION
### Description of the Change

The WMTS specification is very flexible with the format and structure of provided imagery tiles. WebWorldWind currently only supports specific coordinate systems and tile subdivisions of the WMTS specification. The creation of a WMTS layer in WebWorldWind requires a configuration object with the TileMatrixSet specified. The TileMatrixSet includes the CRS and tile subdivision information.

The WmtsLayer object provides a utility function for creating the proper configuration object for the WmtsLayer constructor. The utility function checked for the compatible CRS; however, a check of the tile subdivision was left until the constructor. In some cases, this allowed a TileMatrixSet which included a compatible CRS but not a compatible tile subdivision to be specified in the configuration object. When the configuration object was provided to the constructor and the tile subdivision check occurred, an error is thrown and the WMTS layer is not displayed.

Notably, #113 demonstrates a case where two TileMatrixSet's are available from the server. Both have compatible CRS, but only the second has a compatible tile subdivision. The configuration object utility function ignored the subdivision incompatibility and provided a bad configuration to the WmtsLayer.

This change refactors the utility function and constructor slightly to conduct both the CRS and tile subdivision check. It is fully backwards compatible and ensures compatible CRS and tile subdivision checks happen in both the utility function and WmtsLayer constructor.

### Why Should This Be In Core?

Corrects an oversight in the configuration of a WmtsLayer by checking the CRS and tile subdivision in both the config object creation function and the constructor.

### Benefits

More robust handling of available TileMatrixSet from an WMTS server.

### Applicable Issues

Closes #113 