### PR TITLE
Fix Polygon side texture matrix calculation

### DIFF
--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -666,12 +666,6 @@ define([
             program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
 
             if (hasSideTextures && !dc.pickingMode) {
-                this.activeTexture = dc.gpuResourceCache.resourceForKey(this.capImageSource());
-                if (!this.activeTexture) {
-                    this.activeTexture =
-                        dc.gpuResourceCache.retrieveTexture(dc.currentGlContext, this.capImageSource());
-                }
-
                 if (applyLighting) {
                     program.loadApplyLighting(gl, true);
                     gl.enableVertexAttribArray(program.normalVectorLocation);
@@ -696,7 +690,7 @@ define([
                             coordByteOffset + 12);
 
                         this.scratchMatrix.setToIdentity();
-                        this.scratchMatrix.multiplyByTextureTransform(this.activeTexture);
+                        this.scratchMatrix.multiplyByTextureTransform(sideTexture);
 
                         program.loadTextureEnabled(gl, true);
                         program.loadTextureUnit(gl, gl.TEXTURE0);


### PR DESCRIPTION
### Description of the Change

This change fixes the texture used for calculating the texture transform and removes an unnecessary texture fetch for an unused texture.

It follows the comments in  #434 and I've tested the modifications in the Polygons example.

### Applicable Issues

Closes #434