### PR TITLE
Repair PickedObjectList.topPickedObject

### DIFF
--- a/src/pick/PickedObjectList.js
+++ b/src/pick/PickedObjectList.js
@@ -98,7 +98,7 @@ define([],
 
             if (size > 1) {
                 for (var i = 0; i < size; i++) {
-                    if (this.objects[[i].isOnTop]) {
+                    if (this.objects[i].isOnTop) {
                         return this.objects[i];
                     }
                 }


### PR DESCRIPTION
- Syntax errors in PickedObjectList.topPickedObject resulted in potentially incorrect return values with two or more picked objects.
- Fixes #203