### PR TITLE
Addressed text texture re-rendering according to cached contents

### DIFF
--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1530,14 +1530,14 @@ define([
          * @returns {Texture} A texture {@link Texture} with the specified text string, font, colors, and outline.
          */
         DrawContext.prototype.createTextTexture = function (text, textAttributes) {
-            if (text === null || textAttributes === null) {
+            if (!text || !textAttributes) {
                 return null;
             }
 
-            var textureKey = text + textAttributes.stateKey;
+            var textureKey = this.textTextureStateKey(text, textAttributes);
             var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
-            if (text !== null && !texture && textAttributes !== null) {
+            if (!texture) {
                 this.textRenderer.textColor = textAttributes.color;
                 this.textRenderer.typeFace = textAttributes.font;
                 this.textRenderer.enableOutline = textAttributes.enableOutline;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1530,6 +1530,9 @@ define([
          * @returns {Texture} A texture {@link Texture} with the specified text string, font, colors, and outline.
          */
         DrawContext.prototype.createTextTexture = function (text, textAttributes) {
+            if (text === null || textAttributes === null) {
+                return null;
+            }
 
             var textureKey = text + textAttributes.stateKey;
             var texture = this.gpuResourceCache.resourceForKey(textureKey);

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -39,7 +39,6 @@ define([
         '../shapes/SurfaceShape',
         '../shapes/SurfaceShapeTileBuilder',
         '../render/SurfaceTileRenderer',
-        '../shapes/TextAttributes',
         '../render/TextRenderer',
         '../geom/Vec2',
         '../geom/Vec3',
@@ -67,7 +66,6 @@ define([
               SurfaceShape,
               SurfaceShapeTileBuilder,
               SurfaceTileRenderer,
-              TextAttributes,
               TextRenderer,
               Vec2,
               Vec3,
@@ -1533,24 +1531,20 @@ define([
          */
         DrawContext.prototype.renderText = function (text, textAttributes) {
 
-            if (!(textAttributes instanceof TextAttributes) || textAttributes === null) {
-                console.log("Error. DrawContext.renderText is receiving a wrong TextAttributes object");
-            } else {
-                var textureKey = text + textAttributes.stateKey;
-                var texture = this.gpuResourceCache.resourceForKey(textureKey);
+            var textureKey = text + textAttributes.stateKey;
+            var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
-                if (text !== null && !texture) {
-                    this.textRenderer.textColor = textAttributes.color;
-                    this.textRenderer.typeFace = textAttributes.font;
-                    this.textRenderer.enableOutline = textAttributes.enableOutline;
-                    this.textRenderer.outlineColor = textAttributes.outlineColor;
-                    this.textRenderer.outlineWidth = textAttributes.outlineWidth;
-                    texture = this.textRenderer.renderText(text);
-                }
-
-                this.gpuResourceCache.putResource(textureKey, texture, texture.size);
-                return texture;
+            if (text !== null && !texture && textAttributes !== null) {
+                this.textRenderer.textColor = textAttributes.color;
+                this.textRenderer.typeFace = textAttributes.font;
+                this.textRenderer.enableOutline = textAttributes.enableOutline;
+                this.textRenderer.outlineColor = textAttributes.outlineColor;
+                this.textRenderer.outlineWidth = textAttributes.outlineWidth;
+                texture = this.textRenderer.renderText(text);
             }
+
+            this.gpuResourceCache.putResource(textureKey, texture, texture.size);
+            return texture;
         };
 
         return DrawContext;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1559,6 +1559,10 @@ define([
          * with texture rendering.
          */
         DrawContext.prototype.computeTextTextureStateKey = function (text, attributes) {
+            if (!text || !attributes) {
+                return null;
+            }
+
             return text +
                 "c " + attributes.color.toHexString(true) +
                 " f " + attributes.font.toString() +

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1534,7 +1534,7 @@ define([
                 return null;
             }
 
-            var textureKey = this.textTextureStateKey(text, textAttributes);
+            var textureKey = this.computeTextTextureStateKey(text, textAttributes);
             var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
             if (!texture) {
@@ -1550,13 +1550,21 @@ define([
             return texture;
         };
 
-        DrawContext.prototype.textTextureStateKey = function (text, textAttributes) {
+        /**
+         * Computes a state key that relates to a text label, foregoing the TextAttributes {@link TextAttributes}
+         * properties that are not related to texture rendering (offset, scale, and depthTest).
+         * @param {String} text The label's string of text.
+         * @param {TextAttributes} attributes The TextAttributes object associated with the text label to render.
+         * @returns {String} A state key composed of the original string of text plus the TextAttributes associated
+         * with texture rendering.
+         */
+        DrawContext.prototype.computeTextTextureStateKey = function (text, attributes) {
             return text +
-                "c " + textAttributes.color.toHexString(true) +
-                " f " + textAttributes.font.toString() +
-                " eo " + textAttributes.enableOutline +
-                " ow " + textAttributes.outlineWidth +
-                " oc " + textAttributes.outlineColor.toHexString(true);
+                "c " + attributes.color.toHexString(true) +
+                " f " + attributes.font.toString() +
+                " eo " + attributes.enableOutline +
+                " ow " + attributes.outlineWidth +
+                " oc " + attributes.outlineColor.toHexString(true);
         };
 
         return DrawContext;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1550,5 +1550,14 @@ define([
             return texture;
         };
 
+        DrawContext.prototype.textTextureStateKey = function (text, textAttributes) {
+            return text +
+                "c " + textAttributes.color.toHexString(true) +
+                " f " + textAttributes.font.toString() +
+                " eo " + textAttributes.enableOutline +
+                " ow " + textAttributes.outlineWidth +
+                " oc " + textAttributes.outlineColor.toHexString(true);
+        };
+
         return DrawContext;
     });

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1530,7 +1530,8 @@ define([
          */
         DrawContext.prototype.renderText = function (text, textAttributes) {
 
-            var texture = null;
+            var textureKey = text + JSON.stringify(textAttributes);
+            var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
             if (text != null && textAttributes != null) {
                 this.textRenderer.textColor = textAttributes.color;
@@ -1541,6 +1542,7 @@ define([
                 texture = this.textRenderer.renderText(text);
             }
 
+            this.gpuResourceCache.putResource(textureKey, texture, texture.size);
             return texture;
         };
 

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1530,10 +1530,12 @@ define([
          */
         DrawContext.prototype.renderText = function (text, textAttributes) {
 
-            var textureKey = text + JSON.stringify(textAttributes);
+            // TODO: Maybe handling an exception to test if textAttributes is typeof TextAttributes
+
+            var textureKey = text + textAttributes.stateKey;
             var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
-            if (text != null && textAttributes != null) {
+            if (text !== null && textAttributes !== null) {
                 this.textRenderer.textColor = textAttributes.color;
                 this.textRenderer.typeFace = textAttributes.font;
                 this.textRenderer.enableOutline = textAttributes.enableOutline;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1535,7 +1535,7 @@ define([
             var textureKey = text + textAttributes.stateKey;
             var texture = this.gpuResourceCache.resourceForKey(textureKey);
 
-            if (text !== null && textAttributes !== null) {
+            if (text !== null && textAttributes !== null && !texture) {
                 this.textRenderer.textColor = textAttributes.color;
                 this.textRenderer.typeFace = textAttributes.font;
                 this.textRenderer.enableOutline = textAttributes.enableOutline;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1529,7 +1529,7 @@ define([
          * See TextAttributes {@link TextAttributes}.
          * @returns {Texture} A texture {@link Texture} with the specified text string, font, colors, and outline.
          */
-        DrawContext.prototype.renderText = function (text, textAttributes) {
+        DrawContext.prototype.createTextTexture = function (text, textAttributes) {
 
             var textureKey = text + textAttributes.stateKey;
             var texture = this.gpuResourceCache.resourceForKey(textureKey);

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -268,7 +268,7 @@ define([
         ScreenCreditController.prototype.drawStringCredit = function (dc, credit, y) {
             var imageWidth, imageHeight, activeTexture, gl, program, x;
 
-            activeTexture = dc.renderText(credit.text, credit.textAttributes);
+            activeTexture = dc.createTextTexture(credit.text, credit.textAttributes);
 
             imageWidth = activeTexture.imageWidth;
             imageHeight = activeTexture.imageHeight;

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -266,14 +266,9 @@ define([
 
         // Internal use only. Intentionally not documented.
         ScreenCreditController.prototype.drawStringCredit = function (dc, credit, y) {
-            var imageWidth, imageHeight, activeTexture, textureKey, gl, program, x;
+            var imageWidth, imageHeight, activeTexture, gl, program, x;
 
-            textureKey = credit.text + credit.textAttributes.font.toString();
-            activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
-            if (!activeTexture) {
-                activeTexture = dc.renderText(credit.text, credit.textAttributes);
-                dc.gpuResourceCache.putResource(textureKey, activeTexture, activeTexture.size);
-            }
+            activeTexture = dc.renderText(credit.text, credit.textAttributes);
 
             imageWidth = activeTexture.imageWidth;
             imageHeight = activeTexture.imageHeight;

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -283,15 +283,7 @@ define([
                 return null;
             }
 
-            // var labelFont = this.attributes.textAttributes.font;
-            // var labelKey = this.label + labelFont.toString();
-            //
-            // this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
-            //
-            // if (!this.labelTexture) {
-                this.labelTexture = dc.renderText(this.label, this.attributes.textAttributes);
-            // dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
-            // }
+            this.labelTexture = dc.renderText(this.label, this.attributes.textAttributes);
 
             w = this.labelTexture.imageWidth;
             h = this.labelTexture.imageHeight;
@@ -330,7 +322,7 @@ define([
                 leaderOffsetY = 0;
             }
 
-            if (this.attributes.stateKey != this.lastStateKey) {
+            if (this.attributes.stateKey !== this.lastStateKey) {
                 this.calloutPoints = this.createCallout(
                     width, height,
                     leaderOffsetX, leaderOffsetY,
@@ -463,7 +455,7 @@ define([
 
             // Attributes have changed. We need to track this because the callout vbo data may
             // have changed if scaled or text wrapping changes callout dimensions
-            var calloutAttributesChanged = (this.attributes.stateKey != this.lastStateKey);
+            var calloutAttributesChanged = (this.attributes.stateKey !== this.lastStateKey);
 
             // Create new cache key if callout drawing points have changed
             if (!this.calloutCacheKey || calloutAttributesChanged) {

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -283,7 +283,7 @@ define([
                 return null;
             }
 
-            this.labelTexture = dc.renderText(this.label, this.attributes.textAttributes);
+            this.labelTexture = dc.createTextTexture(this.label, this.attributes.textAttributes);
 
             w = this.labelTexture.imageWidth;
             h = this.labelTexture.imageHeight;

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -283,15 +283,15 @@ define([
                 return null;
             }
 
-            var labelFont = this.attributes.textAttributes.font;
-            var labelKey = this.label + labelFont.toString();
-
-            this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
-
-            if (!this.labelTexture) {
+            // var labelFont = this.attributes.textAttributes.font;
+            // var labelKey = this.label + labelFont.toString();
+            //
+            // this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
+            //
+            // if (!this.labelTexture) {
                 this.labelTexture = dc.renderText(this.label, this.attributes.textAttributes);
-                dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
-            }
+            // dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
+            // }
 
             w = this.labelTexture.imageWidth;
             h = this.labelTexture.imageHeight;

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -476,8 +476,7 @@ define([
 
             this.imageBounds = WWMath.boundingRectForUnitQuad(this.imageTransform);
 
-            // If there's a label, perform these same operations for the label texture, creating that texture if it
-            // doesn't already exist.
+            // If there's a label, perform these same operations for the label texture.
 
             if (this.mustDrawLabel()) {
 

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -480,14 +480,8 @@ define([
             // doesn't already exist.
 
             if (this.mustDrawLabel()) {
-                var labelFont = this.activeAttributes.labelAttributes.font,
-                    labelKey = this.label + labelFont.toString();
 
-                this.labelTexture = dc.gpuResourceCache.resourceForKey(labelKey);
-                if (!this.labelTexture) {
-                    this.labelTexture = dc.renderText(this.label, this.activeAttributes.labelAttributes);
-                    dc.gpuResourceCache.putResource(labelKey, this.labelTexture, this.labelTexture.size);
-                }
+                this.labelTexture = dc.renderText(this.label, this.activeAttributes.labelAttributes);
 
                 w = this.labelTexture.imageWidth;
                 h = this.labelTexture.imageHeight;

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -480,7 +480,7 @@ define([
 
             if (this.mustDrawLabel()) {
 
-                this.labelTexture = dc.renderText(this.label, this.activeAttributes.labelAttributes);
+                this.labelTexture = dc.createTextTexture(this.label, this.activeAttributes.labelAttributes);
 
                 w = this.labelTexture.imageWidth;
                 h = this.labelTexture.imageHeight;

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -311,8 +311,8 @@ define([
             if (!this.computeScreenPointAndEyeDistance(dc)) {
                 return null;
             }
-            
-            this.activeTexture = dc.renderText(this.text, this.activeAttributes);
+
+            this.activeTexture = dc.createTextTexture(this.text, this.activeAttributes);
 
             w = this.activeTexture.imageWidth;
             h = this.activeTexture.imageHeight;

--- a/src/shapes/Text.js
+++ b/src/shapes/Text.js
@@ -311,15 +311,8 @@ define([
             if (!this.computeScreenPointAndEyeDistance(dc)) {
                 return null;
             }
-
-            var labelFont = this.activeAttributes.font,
-                textureKey = this.text + labelFont.toString();
-
-            this.activeTexture = dc.gpuResourceCache.resourceForKey(textureKey);
-            if (!this.activeTexture) {
-                this.activeTexture = dc.renderText(this.text, this.activeAttributes);
-                dc.gpuResourceCache.putResource(textureKey, this.activeTexture, this.activeTexture.size);
-            }
+            
+            this.activeTexture = dc.renderText(this.text, this.activeAttributes);
 
             w = this.activeTexture.imageWidth;
             h = this.activeTexture.imageHeight;


### PR DESCRIPTION
### Description of the Change
- Addressed a bug introduced by the refactor of text rendering facilities that pervaded the textures of text labels to be redrawn if their attributes were changed.
- Transferred the responsibility of checking if the aforementioned textures are already cached from `Text` and its subclasses to the new `DrawContext.renderText` function, further aligning the design with its counterpart in WorldWind Android.

### Benefits
These changes address the aforementioned bug and aid in alignment between Web WorldWind and WorldWind Android.

The `Annotations` example text color sliders now work. The label's other properties were tested although no example was added to the branch:

![textupdatingplacemark](https://user-images.githubusercontent.com/7622894/36046424-810edf82-0d9e-11e8-96d1-0850f8e36267.gif)

### Potential Drawbacks
The label's string of text and its TextAttributes object are passing through two functions in sequence for the texture caching to work. In both instances they have checks for `null` and `undefined` cases, but such coupling may be considered sub-optimal.

### Applicable Issues
Closes #177 
Closes #464