### PR TITLE
Fix layer opacity application to renderables

### DIFF
--- a/src/shapes/AbstractMesh.js
+++ b/src/shapes/AbstractMesh.js
@@ -353,12 +353,10 @@ define([
                 }
 
                 color = this.activeAttributes.interiorColor;
-                opacity = color.alpha * dc.currentLayer.opacity;
-
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(opacity >= 1 || dc.pickingMode);
+                gl.depthMask(opacity >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
                 if (hasTexture && (!dc.pickingMode || !this.pickTransparentImagePixels)) {
                     this.activeTexture = dc.gpuResourceCache.resourceForKey(this.activeAttributes.imageSource);
@@ -459,7 +457,7 @@ define([
                 // semi-transparent.
                 gl.depthMask(opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 

--- a/src/shapes/AbstractMesh.js
+++ b/src/shapes/AbstractMesh.js
@@ -294,7 +294,7 @@ define([
                 program = dc.currentProgram,
                 currentData = this.currentData,
                 hasTexture = this.texCoords && !!this.activeAttributes.imageSource,
-                vboId, opacity, color, pickColor, textureBound;
+                vboId, color, pickColor, textureBound;
 
             if (dc.pickingMode) {
                 pickColor = dc.uniquePickColor();
@@ -354,7 +354,7 @@ define([
 
                 color = this.activeAttributes.interiorColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(opacity >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
                 program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
@@ -451,11 +451,9 @@ define([
                 this.applyMvpMatrixForOutline(dc);
 
                 color = this.activeAttributes.outlineColor;
-                opacity = color.alpha * dc.currentLayer.opacity;
-
                 // Disable writing the shape's fragments to the depth buffer when the interior is
                 // semi-transparent.
-                gl.depthMask(opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
                 program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -451,7 +451,7 @@ define([
                 this.pickColor = dc.uniquePickColor();
             }
 
-            program.loadOpacity(gl, this.attributes.opacity);
+            program.loadOpacity(gl, this.attributes.opacity * dc.currentLayer.opacity);
 
             // Attributes have changed. We need to track this because the callout vbo data may
             // have changed if scaled or text wrapping changes callout dimensions

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -451,7 +451,7 @@ define([
                 this.pickColor = dc.uniquePickColor();
             }
 
-            program.loadOpacity(gl, this.attributes.opacity * dc.currentLayer.opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : this.attributes.opacity * dc.currentLayer.opacity);
 
             // Attributes have changed. We need to track this because the callout vbo data may
             // have changed if scaled or text wrapping changes callout dimensions

--- a/src/shapes/Path.js
+++ b/src/shapes/Path.js
@@ -511,7 +511,7 @@ define([
                 program = dc.currentProgram,
                 currentData = this.currentData,
                 numPoints = currentData.tessellatedPoints.length / 3,
-                vboId, opacity, color, pickColor, stride, nPts;
+                vboId, color, pickColor, stride, nPts;
 
             this.applyMvpMatrix(dc);
 
@@ -546,7 +546,7 @@ define([
             if (this.mustDrawInterior(dc)) {
                 color = this.activeAttributes.interiorColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
                 program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
@@ -563,7 +563,7 @@ define([
 
                 color = this.activeAttributes.outlineColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
                 program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 

--- a/src/shapes/Path.js
+++ b/src/shapes/Path.js
@@ -545,13 +545,10 @@ define([
 
             if (this.mustDrawInterior(dc)) {
                 color = this.activeAttributes.interiorColor;
-                opacity = color.alpha * dc.currentLayer.opacity;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                if (opacity < 1 && !dc.pickingMode) {
-                    gl.depthMask(false);
-                }
+                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
                 gl.vertexAttribPointer(program.vertexPointLocation, 3, gl.FLOAT, false, 0, 0);
                 gl.drawArrays(gl.TRIANGLE_STRIP, 0, numPoints);
@@ -565,13 +562,10 @@ define([
                 }
 
                 color = this.activeAttributes.outlineColor;
-                opacity = color.alpha * dc.currentLayer.opacity;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                if (opacity < 1 && !dc.pickingMode) {
-                    gl.depthMask(false);
-                }
+                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 

--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -634,7 +634,7 @@ define([
                 }
             }
 
-            program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity * this.currentVisibility);
 
             // Draw the leader line first so that the image and label have visual priority.
             if (this.mustDrawLeaderLine(dc)) {

--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -558,11 +558,10 @@ define([
             }
 
             color = this.activeAttributes.interiorColor;
-            opacity = color.alpha * dc.currentLayer.opacity;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
-            program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
             stride = 12 + (hasCapTexture ? 8 : 0) + (applyLighting ? 12 : 0);
 
@@ -659,11 +658,10 @@ define([
             }
 
             color = this.activeAttributes.interiorColor;
-            opacity = color.alpha * dc.currentLayer.opacity;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
-            program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
             if (hasSideTextures && !dc.pickingMode) {
                 if (applyLighting) {
@@ -865,12 +863,10 @@ define([
                 }
 
                 color = this.activeAttributes.outlineColor;
-                opacity = color.alpha * dc.currentLayer.opacity;
-                // Disable writing the shape's fragments to the depth buffer when the outline is
-                // semi-transparent.
-                gl.depthMask(opacity >= 1 || dc.pickingMode);
+                // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
+                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 

--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -532,7 +532,7 @@ define([
                 hasCapTexture = !!this.hasCapTexture(),
                 applyLighting = this.activeAttributes.applyLighting,
                 numCapVertices = currentData.capTriangles.length / (hasCapTexture ? 5 : 3),
-                vboId, opacity, color, stride, textureBound, capBuffer;
+                vboId, color, stride, textureBound, capBuffer;
 
             // Assume no cap texture.
             program.loadTextureEnabled(gl, false);
@@ -559,7 +559,7 @@ define([
 
             color = this.activeAttributes.interiorColor;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
             program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
@@ -659,7 +659,7 @@ define([
 
             color = this.activeAttributes.interiorColor;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
             program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 
@@ -864,7 +864,7 @@ define([
 
                 color = this.activeAttributes.outlineColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha >= 1 || dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
                 program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
 

--- a/src/shapes/ScreenImage.js
+++ b/src/shapes/ScreenImage.js
@@ -367,6 +367,7 @@ define([
             if (dc.pickingMode) {
                 this.pickColor = dc.uniquePickColor();
                 program.loadColor(gl, this.pickColor);
+                program.loadOpacity(gl, 1);
             } else {
                 program.loadColor(gl, this.imageColor);
                 program.loadOpacity(gl, this.opacity * this.layer.opacity);


### PR DESCRIPTION
### Description of the Change

The application and use of layer opacity for regular and pick rendering differed throughout the SDK. This change unifies the application of layer opacity for picking and regular drawing and fixes some cases where opacity was applied twice.

### Why Should This Be In Core?

### Benefits

### Potential Drawbacks

### Applicable Issues

Closes #469 