### PR TITLE
Update CSS Color String calculation and use

### DIFF
--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -160,8 +160,8 @@ define([
             ctx2D.font = this.typeFace.fontString;
             ctx2D.textBaseline = "top";
             ctx2D.textAlign = this.typeFace.horizontalAlignment;
-            ctx2D.fillStyle = this.textColor.toCSSString();
-            ctx2D.strokeStyle = this.outlineColor.toCSSString();
+            ctx2D.fillStyle = this.textColor.toCssColorString();
+            ctx2D.strokeStyle = this.outlineColor.toCssColorString();
             ctx2D.lineWidth = this.outlineWidth;
             ctx2D.lineCap = "round";
             ctx2D.lineJoin = "round";

--- a/src/render/TextRenderer.js
+++ b/src/render/TextRenderer.js
@@ -160,8 +160,8 @@ define([
             ctx2D.font = this.typeFace.fontString;
             ctx2D.textBaseline = "top";
             ctx2D.textAlign = this.typeFace.horizontalAlignment;
-            ctx2D.fillStyle = this.textColor.toHexString(false);
-            ctx2D.strokeStyle = this.outlineColor.toRGBAString();
+            ctx2D.fillStyle = this.textColor.toCSSString();
+            ctx2D.strokeStyle = this.outlineColor.toCSSString();
             ctx2D.lineWidth = this.outlineWidth;
             ctx2D.lineCap = "round";
             ctx2D.lineJoin = "round";

--- a/src/shapes/SurfaceShape.js
+++ b/src/shapes/SurfaceShape.js
@@ -963,14 +963,14 @@ define([
                 if (!this.pickColor) {
                     this.pickColor = dc.uniquePickColor();
                 }
-                ctx2D.fillStyle = this.pickColor.toCSSString();
+                ctx2D.fillStyle = this.pickColor.toCssColorString();
                 ctx2D.strokeStyle = ctx2D.fillStyle;
                 ctx2D.lineWidth = attributes.outlineWidth;
             } else {
                 var ic = attributes.interiorColor,
                     oc = attributes.outlineColor;
-                ctx2D.fillStyle = new Color(ic.red, ic.green, ic.blue, ic.alpha * this.layer.opacity).toCSSString();
-                ctx2D.strokeStyle = new Color(oc.red, oc.green, oc.blue, oc.alpha * this.layer.opacity).toCSSString();
+                ctx2D.fillStyle = new Color(ic.red, ic.green, ic.blue, ic.alpha * this.layer.opacity).toCssColorString();
+                ctx2D.strokeStyle = new Color(oc.red, oc.green, oc.blue, oc.alpha * this.layer.opacity).toCssColorString();
                 ctx2D.lineWidth = attributes.outlineWidth;
             }
 

--- a/src/shapes/SurfaceShape.js
+++ b/src/shapes/SurfaceShape.js
@@ -963,14 +963,14 @@ define([
                 if (!this.pickColor) {
                     this.pickColor = dc.uniquePickColor();
                 }
-                ctx2D.fillStyle = this.pickColor.toHexString(false);
+                ctx2D.fillStyle = this.pickColor.toCSSString();
                 ctx2D.strokeStyle = ctx2D.fillStyle;
                 ctx2D.lineWidth = attributes.outlineWidth;
             } else {
                 var ic = attributes.interiorColor,
                     oc = attributes.outlineColor;
-                ctx2D.fillStyle = new Color(ic.red, ic.green, ic.blue, ic.alpha * this.layer.opacity).toRGBAString();
-                ctx2D.strokeStyle = new Color(oc.red, oc.green, oc.blue, oc.alpha * this.layer.opacity).toRGBAString();
+                ctx2D.fillStyle = new Color(ic.red, ic.green, ic.blue, ic.alpha * this.layer.opacity).toCSSString();
+                ctx2D.strokeStyle = new Color(oc.red, oc.green, oc.blue, oc.alpha * this.layer.opacity).toCSSString();
                 ctx2D.lineWidth = attributes.outlineWidth;
             }
 

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -339,7 +339,7 @@ define([
         };
 
         /**
-         * Create a rgba color string that conforms to CSS Module Level 3 specification.
+         * Create a rgba color string that conforms to CSS Color Module Level 3 specification.
          * @returns {string} A color string suitable for CSS.
          */
         Color.prototype.toCSSString = function () {
@@ -347,6 +347,7 @@ define([
                 green = Math.round(this.green * 255),
                 blue = Math.round(this.blue * 255);
 
+            // Per the CSS Color Module Level 3 specification, alpha is expressed as floating point value between 0 - 1
             return 'rgba(' + red + ' ,' + green + ' ,' + blue + ' ,' + this.alpha + ')';
         };
 

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -348,7 +348,7 @@ define([
                 blue = Math.round(this.blue * 255);
 
             // Per the CSS Color Module Level 3 specification, alpha is expressed as floating point value between 0 - 1
-            return 'rgba(' + red + ' ,' + green + ' ,' + blue + ' ,' + this.alpha + ')';
+            return 'rgba(' + red + ', ' + green + ', ' + blue + ', ' + this.alpha + ')';
         };
 
         return Color;

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -318,7 +318,7 @@ define([
          * because some uses reject a four-component color specification.
          * @param {Boolean} isUsingAlpha Enable the use of an alpha component.
          * @returns {string} A color string suitable for CSS.
-         * @deprecated since version 0.10.0
+         * @deprecated since version 0.10.0, use toCSSString for valid CSS color strings
          */
         Color.prototype.toHexString = function(isUsingAlpha) {
             // Use Math.ceil() to get 0.75 to map to 0xc0. This is important if the display is dithering.
@@ -339,13 +339,13 @@ define([
         };
 
         /**
-         * Create a rgba color string that CSS can use.
+         * Create a rgba color string that conforms to CSS Module Level 3 specification.
          * @returns {string} A color string suitable for CSS.
          */
-        Color.prototype.toRGBAString = function () {
-            var red = Math.floor(this.red * 255),
-                green = Math.floor(this.green * 255),
-                blue = Math.floor(this.blue * 255);
+        Color.prototype.toCSSString = function () {
+            var red = Math.round(this.red * 255),
+                green = Math.round(this.green * 255),
+                blue = Math.round(this.blue * 255);
 
             return 'rgba(' + red + ' ,' + green + ' ,' + blue + ' ,' + this.alpha + ')';
         };

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -318,6 +318,7 @@ define([
          * because some uses reject a four-component color specification.
          * @param {Boolean} isUsingAlpha Enable the use of an alpha component.
          * @returns {string} A color string suitable for CSS.
+         * @deprecated since version 0.10.0
          */
         Color.prototype.toHexString = function(isUsingAlpha) {
             // Use Math.ceil() to get 0.75 to map to 0xc0. This is important if the display is dithering.

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -318,7 +318,7 @@ define([
          * because some uses reject a four-component color specification.
          * @param {Boolean} isUsingAlpha Enable the use of an alpha component.
          * @returns {string} A color string suitable for CSS.
-         * @deprecated since version 0.10.0, use toCSSString for valid CSS color strings
+         * @deprecated since version 0.10.0, use toCssColorString for valid CSS color strings
          */
         Color.prototype.toHexString = function(isUsingAlpha) {
             // Use Math.ceil() to get 0.75 to map to 0xc0. This is important if the display is dithering.
@@ -342,7 +342,7 @@ define([
          * Create a rgba color string that conforms to CSS Color Module Level 3 specification.
          * @returns {string} A color string suitable for CSS.
          */
-        Color.prototype.toCSSString = function () {
+        Color.prototype.toCssColorString = function () {
             var red = Math.round(this.red * 255),
                 green = Math.round(this.green * 255),
                 blue = Math.round(this.blue * 255);

--- a/src/util/Color.js
+++ b/src/util/Color.js
@@ -222,7 +222,7 @@ define([
             return new Color(redByte / 255, greenByte / 255, blueByte / 255, alphaByte / 255);
         };
 
-        Color.colorFromHex = function(color) {
+        Color.colorFromHex = function (color) {
             var red = parseInt(color.substring(0, 2), 16);
             var green = parseInt(color.substring(2, 4), 16);
             var blue = parseInt(color.substring(4, 6), 16);
@@ -230,7 +230,7 @@ define([
             return Color.colorFromBytes(red, green, blue, alpha);
         };
 
-        Color.colorFromKmlHex = function(color) {
+        Color.colorFromKmlHex = function (color) {
             var alpha = parseInt(color.substring(0, 2), 16);
             var blue = parseInt(color.substring(2, 4), 16);
             var green = parseInt(color.substring(4, 6), 16);
@@ -320,7 +320,7 @@ define([
          * @returns {string} A color string suitable for CSS.
          * @deprecated since version 0.10.0, use toCssColorString for valid CSS color strings
          */
-        Color.prototype.toHexString = function(isUsingAlpha) {
+        Color.prototype.toHexString = function (isUsingAlpha) {
             // Use Math.ceil() to get 0.75 to map to 0xc0. This is important if the display is dithering.
             var redHex = Math.ceil(this.red * 255).toString(16),
                 greenHex = Math.ceil(this.green * 255).toString(16),

--- a/test/util/Color.test.js
+++ b/test/util/Color.test.js
@@ -63,14 +63,13 @@ require([
         });
 
         it("should convert from CSS back to the original value within css 8 bit precision", function () {
-            var err = 1 / 512;
+            var err = 1 / 510;
 
             for (var red = 0; red <= 1; red += 0.0001) {
                 var initialColor = new Color(red, 0, 0, 1);
                 var colorCssString = initialColor.toCssColorString();
                 var colorValues = cssStringParse(colorCssString);
-                var resultColor = new Color(colorValues[0] / 255, colorValues[1] / 255, colorValues[2] / 255, colorValues[3]);
-                var val = Math.abs(resultColor.red - initialColor.red);
+                var resultColor = Color.colorFromBytes(colorValues[0], colorValues[1], colorValues[2], colorValues[3] * 255);
                 expect(Math.abs(resultColor.red - initialColor.red) <= err).toBe(true);
             }
         });

--- a/test/util/Color.test.js
+++ b/test/util/Color.test.js
@@ -33,25 +33,34 @@ require([
         it("should round to the same integer values", function () {
             var r = 0.25, g = 0.07, b = 0.75, a = 0.5; // values which test the rounding scheme
             var result = new Color(r, g, b, a).toCssColorString();
-            expect(result === "rgba(64, 18, 191, 0.5)");
+            expect(result === "rgba(64, 18, 191, 0.5)").toBe(true);
         });
 
         it("should convert from CSS String to the matching byte value", function () {
             var color = new Color(0, 0, 0, 1); // initial color to start testing (similar to DrawContext pickColor)
-            var re = /\d+(\.\d+)?/; // pattern to extract CSS color values from a string
+            var re = /\d+(\.\d+)?/g; // pattern to extract CSS color values from a string
             var tests = 256 * 256; // test two bands of unique pick colors
 
             // convert CSS Color string to byte array
             var cssStringToByte = function (cssString) {
                 // parse the integer values from the css string
-                return re.exec(cssString);
+                var bytes = [];
+                var match;
+                while ((match = re.exec(cssString)) != null) {
+                    bytes.push(match[0]);
+                }
+                for (var i = bytes.length; i < 4; i++) {
+                    bytes.push(0);
+                }
+
+                return bytes;
             };
 
             for (var i = 0; i < tests; i++) {
                 var startColor = color.nextColor().clone();
                 var colorBytes = cssStringToByte(startColor.toCssColorString());
-                var convertedColor = Color.colorFromBytes(colorBytes[0], colorBytes[1], colorBytes[2], colorBytes[3]);
-                expect(startColor.equals(convertedColor));
+                var convertedColor = Color.colorFromBytes(colorBytes[0], colorBytes[1], colorBytes[2], colorBytes[3] * 255);
+                expect(startColor.equals(convertedColor)).toBe(true);
             }
         });
     });

--- a/test/util/Color.test.js
+++ b/test/util/Color.test.js
@@ -29,5 +29,13 @@ require([
             var result = Color.colorFromHex("000000ff");
             expect(result.equals(new Color(0,0,0,1))).toBe(true);
         });
-    })
+    });
+
+    describe("Color-CssColorString", function() {
+        it("testCssColorStringConversionRounding", function() {
+            var r = 0.25, g = 0.07, b = 0.75, a = 0.5; // values which test the rounding scheme
+            var result = new Color(r, g, b, a).toCssColorString();
+            expect(result === "rgba(64, 18, 191, 0.5)");
+        });
+    });
 });

--- a/test/util/Color.test.js
+++ b/test/util/Color.test.js
@@ -15,27 +15,44 @@
  */
 require([
     'src/util/Color'
-], function (
-    Color
-) {
+], function (Color) {
     "use strict";
-    describe("Color-colorFromHex", function() {
-        it("testValidWhiteHex", function() {
+    describe("Color-colorFromHex", function () {
+        it("testValidWhiteHex", function () {
             var result = Color.colorFromHex("ffffffff");
-            expect(result.equals(new Color(1,1,1,1))).toBe(true);
+            expect(result.equals(new Color(1, 1, 1, 1))).toBe(true);
         });
 
-        it("testValidBlackHex", function() {
+        it("testValidBlackHex", function () {
             var result = Color.colorFromHex("000000ff");
-            expect(result.equals(new Color(0,0,0,1))).toBe(true);
+            expect(result.equals(new Color(0, 0, 0, 1))).toBe(true);
         });
     });
 
-    describe("Color-CssColorString", function() {
-        it("testCssColorStringConversionRounding", function() {
+    describe("Converts Color to CSS Compatible Color String", function () {
+        it("should round to the same integer values", function () {
             var r = 0.25, g = 0.07, b = 0.75, a = 0.5; // values which test the rounding scheme
             var result = new Color(r, g, b, a).toCssColorString();
             expect(result === "rgba(64, 18, 191, 0.5)");
+        });
+
+        it("should convert from CSS String to the matching byte value", function () {
+            var color = new Color(0, 0, 0, 1); // initial color to start testing (similar to DrawContext pickColor)
+            var re = /\d+(\.\d+)?/; // pattern to extract CSS color values from a string
+            var tests = 256 * 256; // test two bands of unique pick colors
+
+            // convert CSS Color string to byte array
+            var cssStringToByte = function (cssString) {
+                // parse the integer values from the css string
+                return re.exec(cssString);
+            };
+
+            for (var i = 0; i < tests; i++) {
+                var startColor = color.nextColor().clone();
+                var colorBytes = cssStringToByte(startColor.toCssColorString());
+                var convertedColor = Color.colorFromBytes(colorBytes[0], colorBytes[1], colorBytes[2], colorBytes[3]);
+                expect(startColor.equals(convertedColor));
+            }
         });
     });
 });

--- a/test/util/Color.test.js
+++ b/test/util/Color.test.js
@@ -49,9 +49,6 @@ require([
                 while ((match = re.exec(cssString)) != null) {
                     bytes.push(match[0]);
                 }
-                for (var i = bytes.length; i < 4; i++) {
-                    bytes.push(0);
-                }
 
                 return bytes;
             };


### PR DESCRIPTION
### Description of the Change

This change corrects the calculation of CSS Color. It unifies the use of one string generation method (`toCSSColorString`) for all color rendering (including picking).

The method `toHexString` which also generates a CSS Color compatible string has been marked as deprecated. The CSS Color Module specification does not require hexadecimal color representations to contain an alpha channel. The new CSS Color compliant `toCSSColorString` incorporates an alpha channel to provide transparent colors.

### Applicable Issues

Closes #471 