### PR TITLE
Move copyright symbol on OSM layer

### DIFF
--- a/src/layer/OpenStreetMapImageLayer.js
+++ b/src/layer/OpenStreetMapImageLayer.js
@@ -68,8 +68,8 @@ define([
                 // The pattern for this attribute is described in the WMTS Capabilities document and demonstrated at EOX
                 // Maps site: http://maps.eox.at/
                 if (this.inCurrentFrame) {
-                    dc.screenCreditController.addStringCredit("http://www.openstreetmap.org/copyright, http://maps.eox.at/#data, and http://eox.at", Color.DARK_GRAY);
-                    dc.screenCreditController.addStringCredit("OpenStreetMap { Data © OpenStreetMap contributers, Rendering © MapServer and EOX }", Color.DARK_GRAY);
+                    dc.screenCreditController.addStringCredit("© OpenStreetMap", Color.DARK_GRAY);
+                    dc.screenCreditController.addStringCredit("© EOX.at", Color.DARK_GRAY);
                 }
             }
         };

--- a/src/layer/OpenStreetMapImageLayer.js
+++ b/src/layer/OpenStreetMapImageLayer.js
@@ -68,8 +68,8 @@ define([
                 // The pattern for this attribute is described in the WMTS Capabilities document and demonstrated at EOX
                 // Maps site: http://maps.eox.at/
                 if (this.inCurrentFrame) {
-                    dc.screenCreditController.addStringCredit("© OpenStreetMap", Color.DARK_GRAY);
-                    dc.screenCreditController.addStringCredit("© EOX.at", Color.DARK_GRAY);
+                    dc.screenCreditController.addStringCredit("OpenStreetMap ©", Color.DARK_GRAY);
+                    dc.screenCreditController.addStringCredit("EOX.at ©", Color.DARK_GRAY);
                 }
             }
         };


### PR DESCRIPTION
@PJHogan I've moved the copyright symbol as requested. I think the site should remain EOX.at as www.EOX.at looks to be configured incorrectly.