### PR TITLE
Fix text texture cache usage in DrawContext

### DIFF
--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1544,9 +1544,9 @@ define([
                 this.textRenderer.outlineColor = textAttributes.outlineColor;
                 this.textRenderer.outlineWidth = textAttributes.outlineWidth;
                 texture = this.textRenderer.renderText(text);
+                this.gpuResourceCache.putResource(textureKey, texture, texture.size);
             }
 
-            this.gpuResourceCache.putResource(textureKey, texture, texture.size);
             return texture;
         };
 


### PR DESCRIPTION
### Description of the Change
Changed `DrawContext.createTextTexture` to avoid unneeded calls to `gpuResourceCache.putResource` for existing text textures.
- Was always calling putResource, which was abusing the gpuResourceCache with excessive remove/add activity.
- Now putResource is only called for new text textures.
### Why Should This Be In Core?
createTextTexture was abusing the gpuResourceCache.
### Benefits
Improves cache usage for all WorldWind clients using static text, e.g., Screen Credits.
### Potential Drawbacks
None
### Applicable Issues
Closes #504