### PR TITLE
Improve GPU resource cache management

### DIFF
--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -73,25 +73,33 @@ define([
          * @alias WorldWindow
          * @constructor
          * @classdesc Represents a WorldWind window for an HTML canvas.
-         * @param {String} canvasName The name assigned to the HTML canvas in the document.
+         * @param {String|HTMLCanvasElement} canvasElem The ID assigned to the HTML canvas in the document or the canvas
+         * element itself.
          * @param {ElevationModel} elevationModel An optional argument indicating the elevation model to use for the World
          * Window. If missing or null, a default elevation model is used.
-         * @throws {ArgumentError} If there is no HTML element with the specified name in the document, or if the
+         * @throws {ArgumentError} If there is no HTML element with the specified ID in the document, or if the
          * HTML canvas does not support WebGL.
          */
-        var WorldWindow = function (canvasName, elevationModel) {
+        var WorldWindow = function (canvasElem, elevationModel) {
             if (!(window.WebGLRenderingContext)) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor",
                         "The specified canvas does not support WebGL."));
             }
 
-            // Attempt to get the HTML canvas with the specified name.
-            var canvas = document.getElementById(canvasName);
-            if (!canvas) {
-                throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor",
-                        "The specified canvas name is not in the document."));
+            // Get the actual canvas element either directly or by ID.
+            var canvas;
+            if (canvasElem instanceof HTMLCanvasElement) {
+                canvas = canvasElem;
+            } else {
+                // Attempt to get the HTML canvas with the specified ID.
+                canvas = document.getElementById(canvasElem);
+
+                if (!canvas) {
+                    throw new ArgumentError(
+                        Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor",
+                            "The specified canvas ID is not in the document."));
+                }
             }
 
             // Create the WebGL context associated with the HTML canvas.

--- a/src/cache/GpuResourceCache.js
+++ b/src/cache/GpuResourceCache.js
@@ -180,6 +180,15 @@ define([
 
             return resource;
         };
+        
+        /**
+         * Sets a resource's aging muliplier.
+         * @param {String} key The key of the resource to modify. If null or undefined, the resource's cache entry is not modified.
+         * @param {Number} agingMuliplier The multiplier applied to the age of the resource.
+         */
+        GpuResourceCache.prototype.setResourceAging = function (key, agingMuliplier) {
+            this.entries.setEntryAgingMuliplier(key, agingMuliplier);
+        };
 
         /**
          * Indicates whether a specified resource is in this cache.

--- a/src/cache/GpuResourceCache.js
+++ b/src/cache/GpuResourceCache.js
@@ -182,12 +182,12 @@ define([
         };
         
         /**
-         * Sets a resource's aging muliplier.
+         * Sets a resource's aging factor (multiplier).
          * @param {String} key The key of the resource to modify. If null or undefined, the resource's cache entry is not modified.
-         * @param {Number} agingMuliplier The multiplier applied to the age of the resource.
+         * @param {Number} agingFactor A multiplier applied to the age of the resource.
          */
-        GpuResourceCache.prototype.setResourceAging = function (key, agingMuliplier) {
-            this.entries.setEntryAgingMuliplier(key, agingMuliplier);
+        GpuResourceCache.prototype.setResourceAgingFactor = function (key, agingFactor) {
+            this.entries.setEntryAgingFactor(key, agingFactor);
         };
 
         /**

--- a/src/cache/MemoryCache.js
+++ b/src/cache/MemoryCache.js
@@ -17,11 +17,11 @@
  * @exports MemoryCache
  */
 define([
-        '../error/ArgumentError',
-        '../util/Logger'
-    ],
+    '../error/ArgumentError',
+    '../util/Logger'
+],
     function (ArgumentError,
-              Logger) {
+        Logger) {
         "use strict";
 
         /**
@@ -83,7 +83,7 @@ define([
              * @memberof MemoryCache.prototype
              */
             capacity: {
-                get: function() {
+                get: function () {
                     return this._capacity;
                 },
                 set: function (value) {
@@ -192,7 +192,8 @@ define([
                 key: key,
                 entry: entry,
                 size: size,
-                lastUsed: Date.now()
+                lastUsed: Date.now(),
+                agingMuliplier: 1  // 1x = normal aging
             };
 
             this.entries[key] = cacheEntry;
@@ -229,6 +230,27 @@ define([
             var cacheEntry = this.entries[key];
             if (cacheEntry) {
                 this.removeCacheEntry(cacheEntry);
+            }
+        };
+
+        /**
+         * Sets an entry's aging multiplier used to sort the entries for eviction. 
+         * A value of one is normal aging; a value of two invokes 2x aging, causing
+         * the entry to become twice as old as a normal sibling with the same 
+         * 'last used' timestamp. Setting a value of zero would be a "fountain 
+         * of youth" for an entry as it wouldn't age and thus would sort to the 
+         * bottom of the eviction queue.
+         * @param {String} key The key of the entry to modify. If null or undefined, the cache entry is not modified.
+         * @param {Number} agingMuliplier The multiplier applied to the age of the entry when sorting candidates for eviction.
+         * 
+         */
+        MemoryCache.prototype.setEntryAgingMuliplier = function (key, agingMuliplier) {
+            if (!key)
+                return;
+
+            var cacheEntry = this.entries[key];
+            if (cacheEntry) {
+                cacheEntry.agingMuliplier = agingMuliplier;
             }
         };
 
@@ -299,29 +321,51 @@ define([
 
         // Private. Clears this cache to that necessary to contain a specified amount of free space.
         MemoryCache.prototype.makeSpace = function (spaceRequired) {
-            var sortedEntries = [];
+            var sortedEntries = [],
+                now = Date.now();
 
             // Sort the entries from least recently used to most recently used, then remove the least recently used entries
             // until the cache capacity reaches the low water and the cache has enough free capacity for the required
             // space.
-
-            var sizeAtStart = this.usedCapacity;
             for (var key in this.entries) {
                 if (this.entries.hasOwnProperty(key)) {
                     sortedEntries.push(this.entries[key]);
                 }
             }
-
             sortedEntries.sort(function (a, b) {
-                return a.lastUsed - b.lastUsed;
+                var aAge = (now - a.lastUsed) * a.agingMuliplier,
+                    bAge = (now - b.lastUsed) * b.agingMuliplier;
+                return bAge - aAge;
             });
 
+            var DEBUG = false;
+            // BDS: Dump the cache in order of eviction 
+            if (DEBUG) {
+                for (var n = 0, len = sortedEntries.length; n < len; n++) {
+                    console.log(n + ": (" + sortedEntries[n].lastUsed + ") key: " + sortedEntries[n].key);
+                }
+            }
+
+            // BDS: Debugging vars 
+            if (DEBUG) {
+                var minTime = Number.MAX_VALUE, maxTime = 0;
+            }
             for (var i = 0, len = sortedEntries.length; i < len; i++) {
+                if (DEBUG) {
+                    minTime = Math.min(minTime, sortedEntries[i].lastUsed);
+                    maxTime = Math.max(maxTime, sortedEntries[i].lastUsed);
+                }
                 if (this.usedCapacity > this._lowWater || this.freeCapacity < spaceRequired) {
                     this.removeCacheEntry(sortedEntries[i]);
                 } else {
                     break;
                 }
+            }
+            // BDS: Debugging output 
+            if (DEBUG) {
+                console.log("=================");
+                console.log("AGE RANGE: " + (maxTime - minTime) + "ms, ITEMS REMOVED: " + i);
+                console.log("");
             }
         };
 

--- a/src/cache/MemoryCache.js
+++ b/src/cache/MemoryCache.js
@@ -17,11 +17,11 @@
  * @exports MemoryCache
  */
 define([
-    '../error/ArgumentError',
-    '../util/Logger'
-],
+        '../error/ArgumentError',
+        '../util/Logger'
+    ],
     function (ArgumentError,
-        Logger) {
+              Logger) {
         "use strict";
 
         /**
@@ -234,15 +234,15 @@ define([
         };
 
         /**
-         * Sets an entry's aging multiplier used to sort the entries for eviction. 
+         * Sets an entry's aging multiplier used to sort the entries for eviction.
          * A value of one is normal aging; a value of two invokes 2x aging, causing
-         * the entry to become twice as old as a normal sibling with the same 
-         * 'last used' timestamp. Setting a value of zero would be a "fountain 
-         * of youth" for an entry as it wouldn't age and thus would sort to the 
+         * the entry to become twice as old as a normal sibling with the same
+         * 'last used' timestamp. Setting a value of zero would be a "fountain
+         * of youth" for an entry as it wouldn't age and thus would sort to the
          * bottom of the eviction queue.
          * @param {String} key The key of the entry to modify. If null or undefined, the cache entry is not modified.
          * @param {Number} agingMuliplier The multiplier applied to the age of the entry when sorting candidates for eviction.
-         * 
+         *
          */
         MemoryCache.prototype.setEntryAgingMuliplier = function (key, agingMuliplier) {
             if (!key)

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1545,6 +1545,7 @@ define([
                 this.textRenderer.outlineWidth = textAttributes.outlineWidth;
                 texture = this.textRenderer.renderText(text);
                 this.gpuResourceCache.putResource(textureKey, texture, texture.size);
+                this.gpuResourceCache.setResourceAging(textureKey, 100);  // 100x
             }
 
             return texture;

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -1545,7 +1545,7 @@ define([
                 this.textRenderer.outlineWidth = textAttributes.outlineWidth;
                 texture = this.textRenderer.renderText(text);
                 this.gpuResourceCache.putResource(textureKey, texture, texture.size);
-                this.gpuResourceCache.setResourceAging(textureKey, 100);  // 100x
+                this.gpuResourceCache.setResourceAgingFactor(textureKey, 100);  // age this texture 100x faster than normal resources (e.g., tiles)
             }
 
             return texture;

--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -219,7 +219,8 @@ define([
             var gpuResourceCache = dc.gpuResourceCache;
             var texture = new Texture(gl, canvas);
             gpuResourceCache.putResource(this.gpuCacheKey, texture, texture.size);
-
+            gpuResourceCache.setResourceAging(this.gpuCacheKey, 10);   // 10x
+            
             return texture;
         };
 

--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -171,10 +171,7 @@ define([
                 this.gpuCacheKey = this.getCacheKey();
             }
 
-            var gpuResourceCache = dc.gpuResourceCache;
-            var texture = gpuResourceCache.resourceForKey(this.gpuCacheKey);
-
-            return !!texture;
+            return dc.gpuResourceCache.containsResource(this.gpuCacheKey);
         };
 
         /**

--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -216,7 +216,7 @@ define([
             var gpuResourceCache = dc.gpuResourceCache;
             var texture = new Texture(gl, canvas);
             gpuResourceCache.putResource(this.gpuCacheKey, texture, texture.size);
-            gpuResourceCache.setResourceAging(this.gpuCacheKey, 10);   // 10x
+            gpuResourceCache.setResourceAgingFactor(this.gpuCacheKey, 10);   // age this texture 10x faster than normal resources (e.g., tiles)
             
             return texture;
         };


### PR DESCRIPTION
### Description of the Change
Adds an interface to GpuResourceCache and its backing MemoryCache to advance or retard the normal aging of a cache entry.  Typically users of the cache would an _aging multiplier_ on volatile cache entries so they age faster and evict sooner.

### Why Should This Be In Core?
Provides desirable and expected behaviors when viewing the globe such that recently viewed map tiles remain in the cache in preference to temporal text entries like view coordinates.

### Benefits
- Provides an orderly eviction of volatile resources.
- The resource eviction policies are under the control the resource creators. 
- The existing GpuResourceCache and MemoryCache function interfaces are unchanged.

### Potential Drawbacks
- A 100x aging multiplier has been applied to text textures.
- A 10x aging multiplier has been applied to surface shape tiles.

### Applicable Issues
Closes #497