### PR TITLE
Network request throttling

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -910,12 +910,14 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
          *     <li><code>gpuCacheSize</code>: A Number indicating the size in bytes to allocate from GPU memory for
          *     resources such as textures, GLSL programs and buffer objects. Default is 250e6 (250 MB).</li>
          *     <li><code>baseUrl</code>: The URL of the directory containing the WorldWind Library and its resources.</li>
+         *     <li><code>layerRetrievalQueueSize</code>: The number of concurrent tile requests allowed per layer. The default is 16.</li>
          * </ul>
          * @type {{gpuCacheSize: number}}
          */
         WorldWind.configuration = {
             gpuCacheSize: 250e6,
-            baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../')
+            baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../'),
+            layerRetrievalQueueSize: 16
         };
 
         /**

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -116,6 +116,13 @@ define([
             this.retrievalImageFormat = imageFormat;
             this.cachePath = cachePath;
 
+            /**
+             * Controls how many concurrent tile requests are allowed for this layer.
+             * @type {Number}
+             * @default WorldWind.configuration.layerRetrievalQueueSize
+             */
+            this.retrievalQueueSize = WorldWind.configuration.layerRetrievalQueueSize;
+            
             this.levels = new LevelSet(sector, levelZeroDelta, numLevels, tileWidth, tileHeight);
 
             /**
@@ -462,6 +469,10 @@ define([
          */
         TiledImageLayer.prototype.retrieveTileImage = function (dc, tile, suppressRedraw) {
             if (this.currentRetrievals.indexOf(tile.imagePath) < 0) {
+                if (this.currentRetrievals.length > this.retrievalQueueSize) {
+                    return;
+                }
+                
                 if (this.absentResourceList.isResourceAbsent(tile.imagePath)) {
                     return;
                 }

--- a/src/layer/WmtsLayer.js
+++ b/src/layer/WmtsLayer.js
@@ -204,6 +204,13 @@ define([
              * @default 1.75
              */
             this.detailControl = 1.75;
+            
+            /**
+             * Controls how many concurrent tile requests that are allowed for this layer.
+             * @type {Number}
+             * @default WorldWind.configuration.layerRetrievalQueueSize;
+             */
+            this.retrievalQueueSize = WorldWind.configuration.layerRetrievalQueueSize;            
         };
 
         /**
@@ -678,6 +685,9 @@ define([
 
         WmtsLayer.prototype.retrieveTileImage = function (dc, tile) {
             if (this.currentRetrievals.indexOf(tile.imagePath) < 0) {
+                if (this.currentRetrievals.length > this.retrievalQueueSize) {
+                    return;
+                }                
                 if (this.absentResourceList.isResourceAbsent(tile.imagePath)) {
                     return;
                 }


### PR DESCRIPTION
Closes #497 

### Description of the Change
Added a `retrievalQueueSize` property to TileImageLayer and WmtsLayer that limits the number of concurrent tile requests made by a layer.  Added `layerRetrievalQueueSize` to the WorldWind.configuration object allowing applications to override the default layer retrieval queue size (16).

### Why Should This Be In Core?
Prevents the browser's download queue from being saturated with tile requests that may be transient in nature. It also prevents the GPU resource cache from being populated with textures that might not be used.

### Benefits
Improves the performance and behavior of WorldWind clients when views quickly transit through many zoom levels and/or large geographic distances.  At the end of the transit, populating the view with tiles is faster.

### Potential Drawbacks
When zooming quickly from a satellite view to the surface, tiles for intermediate zoom levels may be skipped. When slowly zooming back out through the zoom levels, these skipped tiles will be initially missing until retrieved (which is automatic).  This a change in behavior.

The default `layerRetrievalQueueSize` property value (16) is subjective. 