### PR TITLE
Fix layer reference for ordered rendering

### DIFF
--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -1207,8 +1207,7 @@ define([
                     }
                 }
             }
-            // TODO: Following line commented out as workaround until issue #494 is addressed.
-            // dc.currentLayer = null;
+            dc.currentLayer = null;
             var now = Date.now();
             dc.frameStatistics.layerRenderingTime = now - beginTime;
         };

--- a/src/formats/collada/ColladaScene.js
+++ b/src/formats/collada/ColladaScene.js
@@ -668,7 +668,7 @@ define([
             }
 
             var color = new Color(r, g, b, a);
-            opacity = a * dc.currentLayer.opacity;
+            opacity = a * this.layer.opacity;
             gl.depthMask(opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? this.pickColor : color);
             program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);

--- a/src/shapes/AbstractMesh.js
+++ b/src/shapes/AbstractMesh.js
@@ -354,9 +354,9 @@ define([
 
                 color = this.activeAttributes.interiorColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
                 if (hasTexture && (!dc.pickingMode || !this.pickTransparentImagePixels)) {
                     this.activeTexture = dc.gpuResourceCache.resourceForKey(this.activeAttributes.imageSource);
@@ -453,9 +453,9 @@ define([
                 color = this.activeAttributes.outlineColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is
                 // semi-transparent.
-                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 
@@ -486,7 +486,7 @@ define([
             if (dc.pickingMode) {
                 var pickPosition = this.computePickPosition(dc);
                 var po = new PickedObject(pickColor, this.pickDelegate ? this.pickDelegate : this, pickPosition,
-                    dc.currentLayer, false);
+                    this.layer, false);
                 dc.resolvePick(po);
             }
         };

--- a/src/shapes/Annotation.js
+++ b/src/shapes/Annotation.js
@@ -451,7 +451,7 @@ define([
                 this.pickColor = dc.uniquePickColor();
             }
 
-            program.loadOpacity(gl, dc.pickingMode ? 1 : this.attributes.opacity * dc.currentLayer.opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : this.attributes.opacity * this.layer.opacity);
 
             // Attributes have changed. We need to track this because the callout vbo data may
             // have changed if scaled or text wrapping changes callout dimensions

--- a/src/shapes/Path.js
+++ b/src/shapes/Path.js
@@ -546,9 +546,9 @@ define([
             if (this.mustDrawInterior(dc)) {
                 color = this.activeAttributes.interiorColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
                 gl.vertexAttribPointer(program.vertexPointLocation, 3, gl.FLOAT, false, 0, 0);
                 gl.drawArrays(gl.TRIANGLE_STRIP, 0, numPoints);
@@ -563,9 +563,9 @@ define([
 
                 color = this.activeAttributes.outlineColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 
@@ -608,7 +608,7 @@ define([
             currentData.fillVbo = false;
 
             if (dc.pickingMode) {
-                var po = new PickedObject(pickColor, this.pickDelegate ? this.pickDelegate : this, null, dc.currentLayer,
+                var po = new PickedObject(pickColor, this.pickDelegate ? this.pickDelegate : this, null, this.layer,
                     false);
                 dc.resolvePick(po);
             }

--- a/src/shapes/Polygon.js
+++ b/src/shapes/Polygon.js
@@ -519,7 +519,7 @@ define([
 
             if (dc.pickingMode) {
                 var po = new PickedObject(pickColor, this.pickDelegate ? this.pickDelegate : this, null,
-                    dc.currentLayer, false);
+                    this.layer, false);
                 dc.resolvePick(po);
             }
         };
@@ -559,9 +559,9 @@ define([
 
             color = this.activeAttributes.interiorColor;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
-            program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
             stride = 12 + (hasCapTexture ? 8 : 0) + (applyLighting ? 12 : 0);
 
@@ -659,9 +659,9 @@ define([
 
             color = this.activeAttributes.interiorColor;
             // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-            gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+            gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
             program.loadColor(gl, dc.pickingMode ? pickColor : color);
-            program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+            program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
             if (hasSideTextures && !dc.pickingMode) {
                 if (applyLighting) {
@@ -864,9 +864,9 @@ define([
 
                 color = this.activeAttributes.outlineColor;
                 // Disable writing the shape's fragments to the depth buffer when the interior is semi-transparent.
-                gl.depthMask(color.alpha * dc.currentLayer.opacity >= 1 || dc.pickingMode);
+                gl.depthMask(color.alpha * this.layer.opacity >= 1 || dc.pickingMode);
                 program.loadColor(gl, dc.pickingMode ? pickColor : color);
-                program.loadOpacity(gl, dc.pickingMode ? 1 : dc.currentLayer.opacity);
+                program.loadOpacity(gl, dc.pickingMode ? 1 : this.layer.opacity);
 
                 gl.lineWidth(this.activeAttributes.outlineWidth);
 


### PR DESCRIPTION
### Description of the Change

This changes the ordered renderables use of DrawContext's current layer. DrawContext.currentLayer may be invalid during ordered rendering, the reference has been replaced to an object property of layer assigned during rendering.

Additionally, this PR removes the layer reference following layer rendering.

### Applicable Issues

Closes #494 