### PR TITLE
Repaired unit tests erroneously modifying Vec3.ZERO

### DIFF
--- a/test/geom/Line.test.js
+++ b/test/geom/Line.test.js
@@ -88,7 +88,7 @@ define([
                 var origin = new Vec3(0, 1, 2);
                 var direction = new Vec3(2, 3, 4);
                 var line = new Line(origin, direction);
-                var result = line.pointAt(5, Vec3.ZERO);
+                var result = line.pointAt(5, new Vec3());
 
                 var expectedResult = new Vec3(10, 16, 22);
                 expect(result).toEqual(expectedResult);

--- a/test/geom/Matrix.test.js
+++ b/test/geom/Matrix.test.js
@@ -527,7 +527,7 @@ define([
 
             it("Multiplies the matrix correctly", function () {
                 var targetMatrix = new Matrix(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-                var result = Vec3.ZERO;
+                var result = new Vec3();
 
                 targetMatrix.extractRotationAngles(result);
 
@@ -886,7 +886,7 @@ define([
 
             it("Returns the eye point correctly", function () {
                 var matrix = new Matrix(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-                var result = Vec3.ZERO;
+                var result = new Vec3();
                 matrix.extractEyePoint(result);
 
                 expect(result).toEqual(new Vec3(-116, -137, -158));
@@ -905,7 +905,7 @@ define([
 
             it("Returns the vector correctly", function () {
                 var matrix = new Matrix(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15);
-                var result = Vec3.ZERO;
+                var result = new Vec3();
                 matrix.extractForwardVector(result);
 
                 expect(result).toEqual(new Vec3(-8, -9, -10));

--- a/test/geom/Vec3.test.js
+++ b/test/geom/Vec3.test.js
@@ -39,14 +39,14 @@ define([
         it("Should return the average of a vector", function () {
             var vec3_a = new Vec3(1, 2, 3);
             var vec3_b = new Vec3(3, 2, 1);
-            var vec3_average = Vec3.average([vec3_a, vec3_b], Vec3.ZERO);
+            var vec3_average = Vec3.average([vec3_a, vec3_b], new Vec3());
             expect(vec3_average).toEqual(new Vec3(2, 2, 2));
         });
 
 
         it("Should return the average a specified array of points packed into a single array", function () {
             var pointArray = [1, 2, 3, 3, 2, 1];
-            expect(Vec3.averageOfBuffer(pointArray, Vec3.ZERO)).toEqual(new Vec3(2, 2, 2));
+            expect(Vec3.averageOfBuffer(pointArray, new Vec3())).toEqual(new Vec3(2, 2, 2));
         });
 
         describe("Test the colinearity of three arrays", function () {
@@ -126,13 +126,13 @@ define([
         describe('#Set components', function () {
 
             it('sets vector equal to different vector', function () {
-                var vec3 = Vec3.ZERO;
+                var vec3 = new Vec3();
                 vec3.set(2, 3, 4);
                 expect(vec3).toEqual(new Vec3(2, 3, 4));
             });
 
             it('sets vector and verify by components', function () {
-                var vec3 = Vec3.ZERO;
+                var vec3 = new Vec3();
                 vec3.set(5, 6, 7);
                 expect(vec3[0]).toEqual(5);
                 expect(vec3[1]).toEqual(6);
@@ -141,7 +141,7 @@ define([
         });
 
         it("Copies the component of a Vec3", function () {
-            var destination = Vec3.ZERO;
+            var destination = new Vec3();
             var source = new Vec3(2, 3, 4);
             destination.copy(source);
             expect(destination).toEqual(source);


### PR DESCRIPTION
Several unit tests erroneously modified the constant object Vec3.ZERO, resulting in undefined behavior in components that rely on this value.

Constants as mutable objects was an intentional design choice, which we'll be revisiting in light of this and other bugs like it.