### PR TITLE
Enhanced the accuracy of ElevationModel's min/max elevations

### DIFF
--- a/src/globe/ElevationCoverage.js
+++ b/src/globe/ElevationCoverage.js
@@ -97,13 +97,30 @@ define(['../error/ArgumentError',
         /**
          * Returns the minimum and maximum elevations within a specified sector.
          * @param {Sector} sector The sector for which to determine extreme elevations.
-         * @returns {Number[]} An array containing the minimum and maximum elevations within the specified sector,
-         * or null if the specified sector is outside this elevation model's coverage area or if the server data is not yet
-         * available.
-         * @throws {ArgumentError} If the specified sector is null or undefined.
+         * @param {Number[]} result An array in which to return the requested minimum and maximum elevations.
+         * @returns {Boolean} true if the coverage completely fills the sector with data, false otherwise.
+         * @throws {ArgumentError} If any argument is null or undefined
          */
-        ElevationCoverage.prototype.minAndMaxElevationsForSector = function (sector) {
-            return [0, 0];
+        ElevationCoverage.prototype.minAndMaxElevationsForSector = function (sector, result) {
+            if (!sector) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "ElevationCoverage", "minAndMaxElevationsForSector", "missingSector"));
+            }
+
+            if (!result) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "ElevationCoverage", "minAndMaxElevationsForSector", "missingResult"));
+            }
+
+            if (result[0] > 0) { // min elevation
+                result[0] = 0;
+            }
+
+            if (result[1] < 0) { // max elevation
+                result[1] = 0;
+            }
+
+            return true;
         };
 
         /**

--- a/src/globe/ElevationImage.js
+++ b/src/globe/ElevationImage.js
@@ -94,6 +94,12 @@ define([
              */
             this.hasData = true;
 
+            /**
+             * Internal use only
+             * true if any pixel in the image has a NO_DATA value, false otherwise.
+             * @ignore
+             */
+            this.hasMissingData = false;
         };
 
         /**
@@ -349,9 +355,11 @@ define([
          */
         ElevationImage.prototype.findMinAndMaxElevation = function () {
             this.hasData = false;
+            this.hasMissingData = false;
+
             if (this.imageData && (this.imageData.length > 0)) {
                 this.minElevation = Number.MAX_VALUE;
-                this.maxElevation = -this.minElevation;
+                this.maxElevation = -Number.MAX_VALUE;
 
                 var pixels = this.imageData,
                     pixelCount = this.imageWidth * this.imageHeight;
@@ -367,6 +375,8 @@ define([
                         if (this.maxElevation < p) {
                             this.maxElevation = p;
                         }
+                    } else {
+                        this.hasMissingData = true;
                     }
                 }
             }

--- a/test/globe/ElevationModel.test.js
+++ b/test/globe/ElevationModel.test.js
@@ -33,8 +33,15 @@ define([
 
         MockCoverage.prototype = Object.create(TiledElevationCoverage.prototype);
 
-        MockCoverage.prototype.minAndMaxElevationsForSector = function (sector) {
-            return [this.minElevation, this.maxElevation];
+        MockCoverage.prototype.minAndMaxElevationsForSector = function (sector, result) {
+            if (result[0] > this.minElevation) {
+                result[0] = this.minElevation;
+            }
+            if (result[1] < this.maxElevation) {
+                result[1] = this.maxElevation;
+            }
+
+            return true;
         };
 
         MockCoverage.prototype.elevationAtLocation = function (latitude, longitude) {
@@ -95,13 +102,13 @@ define([
                 var n = 12;
                 var em = new ElevationModel();
                 for (var i = 0; i < n; i++) {
-                    var c = new MockCoverage(n - i + 1, -i - 1, i + 1);
+                    var c = new MockCoverage(i + 1, -i - 1, i + 1);
                     em.addCoverage(c);
                 }
 
                 var minMax = em.minAndMaxElevationsForSector(new Sector(-1, 1, -1, 1));
-                expect(minMax[0]).toEqual(-n);
-                expect(minMax[1]).toEqual(n);
+                expect(minMax[0]).toEqual(-1);
+                expect(minMax[1]).toEqual(1);
             });
 
             it("Returns correct min and max elevations for a sector when some coverages are disabled", function () {
@@ -110,13 +117,14 @@ define([
                 for (var i = 0; i < n; i++) {
                     var c = new MockCoverage(i + 1, -i - 1, i + 1);
                     em.addCoverage(c);
+                    if (i < 2) {
+                        c.enabled = false;
+                    }
                 }
 
-                em.coverages[0].enabled = false;
-                em.coverages[1].enabled = false;
                 var minMax = em.minAndMaxElevationsForSector(new Sector(-1, 1, -1, 1));
-                expect(minMax[0]).toEqual(-10);
-                expect(minMax[1]).toEqual(10);
+                expect(minMax[0]).toEqual(-3);
+                expect(minMax[1]).toEqual(3);
             });
 
             it("Returns correct elevation for a location", function () {


### PR DESCRIPTION
ElevationModel's min/max elevations interface is used indirectly by terrain and image tile rendering to determine level of detail. This change restores min/max accuracy to its pre-composition state, ensuring that terrain and image level of detail behaves as it has been.

- Corrected minElevation and maxElevation to return zero when the model has no coverages, or when all coverages are disabled
- Updated minAndMaxElevationsForSector to consult only the necessary coverages for a given sector
- Updated ElevationModel's unit tests to account for changes in the minAndMaxElevationsForSector interface and behavior
- Relates to epic #575