### PR TITLE
Simplify the moveTo method in SurfaceCircle and SurfaceEllipse

### DIFF
--- a/src/shapes/SurfaceCircle.js
+++ b/src/shapes/SurfaceCircle.js
@@ -168,7 +168,7 @@ define(['../error/ArgumentError',
         };
 
         // Internal use only. Intentionally not documented.
-        SurfaceCircle.prototype.moveTo = function (position) {
+        SurfaceCircle.prototype.moveTo = function (globe, position) {
             this.center = position;
         };
 

--- a/src/shapes/SurfaceCircle.js
+++ b/src/shapes/SurfaceCircle.js
@@ -168,8 +168,8 @@ define(['../error/ArgumentError',
         };
 
         // Internal use only. Intentionally not documented.
-        SurfaceCircle.prototype.moveTo = function (globe, position) {
-            this.center = this.computeShiftedLocations(globe, this.getReferencePosition(), position, [this.center])[0];
+        SurfaceCircle.prototype.moveTo = function (position) {
+            this.center = position;
         };
 
         /**

--- a/src/shapes/SurfaceEllipse.js
+++ b/src/shapes/SurfaceEllipse.js
@@ -218,7 +218,7 @@ define([
         };
 
         // Internal use only. Intentionally not documented.
-        SurfaceEllipse.prototype.moveTo = function (position) {
+        SurfaceEllipse.prototype.moveTo = function (globe, position) {
             this.center = position;
         };
 

--- a/src/shapes/SurfaceEllipse.js
+++ b/src/shapes/SurfaceEllipse.js
@@ -218,8 +218,8 @@ define([
         };
 
         // Internal use only. Intentionally not documented.
-        SurfaceEllipse.prototype.moveTo = function (globe, position) {
-            this.center = this.computeShiftedLocations(globe, this.getReferencePosition(), position, [this.center])[0];
+        SurfaceEllipse.prototype.moveTo = function (position) {
+            this.center = position;
         };
 
         /**


### PR DESCRIPTION
### Description of the Change
Refactoring of moveTo method for SurfaceCircle and SurfaceEllipse shapes.

### Why Should This Be In Core?
Optimization for existing methods.

### Benefits
Optimization for existing methods. 
