### PR TITLE
Update WcsDescribeCoverage to WcsCoverageDescriptions to match XML structure

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -233,7 +233,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         './formats/kml/util/ViewVolume',
         './ogc/wcs/WcsCapabilities',
         './ogc/wcs/WcsCoverage',
-        './ogc/wcs/WcsDescribeCoverage',
+        './ogc/wcs/WcsCoverageDescriptions',
         './globe/WcsEarthElevationCoverage',
         './util/WcsTileUrlBuilder',
         './ogc/wcs/WebCoverageService',
@@ -485,7 +485,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
               ViewVolume,
               WcsCapabilities,
               WcsCoverage,
-              WcsDescribeCoverage,
+              WcsCoverageDescriptions,
               WcsEarthElevationCoverage,
               WcsTileUrlBuilder,
               WebCoverageService,
@@ -907,7 +907,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         WorldWind['ViewControlsLayer'] = ViewControlsLayer;
         WorldWind['WcsCapabilities'] = WcsCapabilities;
         WorldWind['WcsCoverage'] = WcsCoverage;
-        WorldWind['WcsDescribeCoverage'] = WcsDescribeCoverage;
+        WorldWind['WcsCoverageDescriptions'] = WcsCoverageDescriptions;
         WorldWind['WcsEarthElevationCoverage'] = WcsEarthElevationCoverage;
         WorldWind['WcsTileUrlBuilder'] = WcsTileUrlBuilder;
         WorldWind['WebCoverageService'] = WebCoverageService;

--- a/src/ogc/wcs/WcsCoverage.js
+++ b/src/ogc/wcs/WcsCoverage.js
@@ -20,12 +20,12 @@ define([
         '../../error/ArgumentError',
         '../../util/Logger',
         '../../ogc/wcs/WcsCapabilities',
-        '../../ogc/wcs/WcsDescribeCoverage'
+        '../../ogc/wcs/WcsCoverageDescriptions'
     ],
     function (ArgumentError,
               Logger,
               WcsCapabilities,
-              WcsDescribeCoverage) {
+              WcsCoverageDescriptions) {
         "use strict";
 
         /**

--- a/src/ogc/wcs/WcsCoverage.js
+++ b/src/ogc/wcs/WcsCoverage.js
@@ -19,24 +19,21 @@
 define([
         '../../error/ArgumentError',
         '../../util/Logger',
-        '../../ogc/wcs/WcsCapabilities',
-        '../../ogc/wcs/WcsCoverageDescriptions'
+        '../../ogc/wcs/WebCoverageService'
     ],
     function (ArgumentError,
               Logger,
-              WcsCapabilities,
-              WcsCoverageDescriptions) {
+              WcsCapabilities) {
         "use strict";
 
         /**
          * A Web Coverage Service version agnostic simple object representation of a coverage. Provides utility methods
          * for common WCS Coverage operations.
          * @param coverageId the name or id of the coverage
-         * @param getCapabilities the WcsCapabilities object representing the capabilities of this coverage
-         * @param describeCoverage the WcsDescribeCoverage object representing the additional parameters of the coverage
+         * @param webCoverageService the WebCoverageService which provided the coverage identified in coverageId
          * @constructor
          */
-        var WcsCoverage = function (coverageId, getCapabilities, describeCoverage) {
+        var WcsCoverage = function (coverageId, webCoverageService) {
 
             /**
              * A simple configuration object with the required parameters for ElevationCoverage.

--- a/src/ogc/wcs/WcsCoverageDescriptions.js
+++ b/src/ogc/wcs/WcsCoverageDescriptions.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 /**
- * @exports WcsDescribeCoverage
+ * @exports WcsCoverageDescriptions
  */
 define([
         '../../error/ArgumentError',
@@ -34,7 +34,7 @@ define([
 
         /**
          * Constructs a simple javascript object representation of an OGC WCS Describe Coverage XML response.
-         * @alias WcsDescribeCoverage
+         * @alias WcsCoverageDescriptions
          * @constructor
          * @classdesc Represents the common properties of a WCS DescribeCoverage document. Common properties are parsed
          * and mapped to a plain javascript object model. Most fields can be accessed as properties named according to
@@ -44,10 +44,10 @@ define([
          * @param {{}} xmlDom an XML DOM representing the WCS DescribeCoverage document.
          * @throws {ArgumentError} If the specified XML DOM is null or undefined.
          */
-        var WcsDescribeCoverage = function (xmlDom) {
+        var WcsCoverageDescriptions = function (xmlDom) {
             if (!xmlDom) {
                 throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "WcsDescribeCoverage", "constructor", "missingDom"));
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WcsCoverageDescriptions", "constructor", "missingDom"));
             }
 
             /**
@@ -60,7 +60,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleDocument = function () {
+        WcsCoverageDescriptions.prototype.assembleDocument = function () {
             // Determine version and update sequence
             var root = this.xmlDom.documentElement;
 
@@ -75,7 +75,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleDocument100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleDocument100 = function (element) {
             this.version = element.getAttribute("version");
 
             var children = element.children || element.childNodes;
@@ -91,7 +91,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleDocument20x = function (element) {
+        WcsCoverageDescriptions.prototype.assembleDocument20x = function (element) {
             var children = element.children || element.childNodes;
 
             for (var c = 0; c < children.length; c++) {
@@ -105,7 +105,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleCoverages100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleCoverages100 = function (element) {
             var children = element.children || element.childNodes, coverage = {};
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
@@ -138,7 +138,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleCoverages20x = function (element) {
+        WcsCoverageDescriptions.prototype.assembleCoverages20x = function (element) {
             var children = element.children || element.childNodes, coverage = {};
             for (var c = 0; c < children.length; c++) {
                 var child = children[c];
@@ -162,7 +162,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleServiceParameters20x = function (element) {
+        WcsCoverageDescriptions.prototype.assembleServiceParameters20x = function (element) {
             var children = element.children || element.childNodes, serviceParameters = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -180,7 +180,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleLonLatEnvelope100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleLonLatEnvelope100 = function (element) {
             var children = element.children || element.childNodes, latLonEnvelope = {};
 
             latLonEnvelope.srsName = element.getAttribute("srsName");
@@ -190,7 +190,7 @@ define([
 
                 if (child.localName === "pos") {
                     latLonEnvelope.pos = latLonEnvelope.pos || [];
-                    latLonEnvelope.pos.push(WcsDescribeCoverage.parseSpacedFloatArray(child.textContent));
+                    latLonEnvelope.pos.push(WcsCoverageDescriptions.parseSpacedFloatArray(child.textContent));
                 }
             }
 
@@ -198,7 +198,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleSupportedCrs100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleSupportedCrs100 = function (element) {
             var children = element.children || element.childNodes, supportedCrs = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -225,7 +225,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleSupportedFormats100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleSupportedFormats100 = function (element) {
             var children = element.children || element.childNodes, supportedFormats = {};
 
             supportedFormats.nativeFormat = element.getAttribute("nativeFormat");
@@ -243,7 +243,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleSupportedInterpolations100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleSupportedInterpolations100 = function (element) {
             var children = element.children || element.childNodes, supportedInterpolations = {};
 
             supportedInterpolations.default = element.getAttribute("default");
@@ -261,7 +261,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleDomainSet100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleDomainSet100 = function (element) {
             var children = element.children || element.childNodes, domainSet = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -276,7 +276,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleSpatialDomain100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleSpatialDomain100 = function (element) {
             var children = element.children || element.childNodes, spatialDomain = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -293,7 +293,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleRangeSet100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleRangeSet100 = function (element) {
             var children = element.children || element.childNodes, rangeSet = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -307,7 +307,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleRangeSetElement100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleRangeSetElement100 = function (element) {
             var children = element.children || element.childNodes, rangeSet = {};
 
             rangeSet.semantic = element.getAttribute("semantic");
@@ -330,7 +330,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleRangeSetAxisDescription100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleRangeSetAxisDescription100 = function (element) {
             var children = element.children || element.childNodes, axisDescriptions = [];
 
             for (var c = 0; c < children.length; c++) {
@@ -345,7 +345,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleRangeSetAxisDescriptionElement100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleRangeSetAxisDescriptionElement100 = function (element) {
             var children = element.children || element.childNodes, axisDescription = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -364,7 +364,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.prototype.assembleRangeSetValues100 = function (element) {
+        WcsCoverageDescriptions.prototype.assembleRangeSetValues100 = function (element) {
             var children = element.children || element.childNodes, values = {};
 
             for (var c = 0; c < children.length; c++) {
@@ -380,7 +380,7 @@ define([
         };
 
         // Internal. Intentionally not documented.
-        WcsDescribeCoverage.parseSpacedFloatArray = function (line) {
+        WcsCoverageDescriptions.parseSpacedFloatArray = function (line) {
             var result = [], elements = line.split(/\s+/);
 
             for (var i = 0; i < elements.length; i++) {
@@ -390,5 +390,5 @@ define([
             return result;
         };
 
-        return WcsDescribeCoverage;
+        return WcsCoverageDescriptions;
     });

--- a/src/ogc/wcs/WebCoverageService.js
+++ b/src/ogc/wcs/WebCoverageService.js
@@ -22,14 +22,14 @@ define([
     '../../util/Promise',
     '../../ogc/wcs/WcsCapabilities',
     '../../ogc/wcs/WcsCoverage',
-    '../../ogc/wcs/WcsDescribeCoverage'
+    '../../ogc/wcs/WcsCoverageDescriptions'
     ],
     function (ArgumentError,
               Logger,
               Promise,
               WcsCapabilities,
               WcsCoverage,
-              WcsDescribeCoverage) {
+              WcsCoverageDescriptions) {
         "use strict";
 
         /**
@@ -60,7 +60,7 @@ define([
 
             /**
              * A map of the coverages to their corresponding DescribeCoverage documents.
-             * @type {WcsDescribeCoverage}
+             * @type {WcsCoverageDescriptions}
              */
             this.coverageDescriptions = null;
         };
@@ -96,7 +96,7 @@ define([
             return service.retrieveCapabilities()
                 .then(function (wcsCapabilities) {
                     service.capabilities = wcsCapabilities;
-                    return service.describeCoverages(wcsCapabilities);
+                    return service.retrieveCoverageDescriptions(wcsCapabilities);
                 })
                 .then(function (coverages) {
                     service.parseCoverages(coverages);
@@ -135,13 +135,13 @@ define([
         };
 
         // Internal use only
-        WebCoverageService.prototype.describeCoverages = function () {
+        WebCoverageService.prototype.retrieveCoverageDescriptions = function () {
             return this.retrieveXml(this.buildDescribeCoverageXmlRequest());
         };
 
         // Internal use only
         WebCoverageService.prototype.parseCoverages = function (xmlDom) {
-            this.coverageDescriptions = new WcsDescribeCoverage(xmlDom);
+            this.coverageDescriptions = new WcsCoverageDescriptions(xmlDom);
             var coverageCount = this.coverageDescriptions.coverages.length;
 
             for (var i = 0; i < coverageCount; i++) {

--- a/test/ogc/wcs/WcsCoverageDescriptions.test.js
+++ b/test/ogc/wcs/WcsCoverageDescriptions.test.js
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 define([
-    'src/ogc/wcs/WcsDescribeCoverage'
-], function (WcsDescribeCoverage) {
+    'src/ogc/wcs/WcsCoverageDescriptions'
+], function (WcsCoverageDescriptions) {
     "use strict";
 
     describe("Constructor testing", function () {
 
         it("should throw an exception when nothing is provided as an argument", function () {
-            expect((function () {new WcsDescribeCoverage(null)})).toThrow();
+            expect((function () {new WcsCoverageDescriptions(null)})).toThrow();
         });
     });
 
@@ -46,33 +46,33 @@ define([
         });
 
         it("should match the coverage name testing:gebco", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var name = wcsDescribeCoverage.coverages[0].name;
+            var name = wcsCoverageDescriptions.coverages[0].name;
 
             expect(name).toBe("testing:gebco");
         });
 
         it("should match the coverage label gebco", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var label = wcsDescribeCoverage.coverages[0].label;
+            var label = wcsCoverageDescriptions.coverages[0].label;
 
             expect(label).toBe("gebco");
         });
 
         it("should match the coverage description Generated from GeoTIFF", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var description = wcsDescribeCoverage.coverages[0].description;
+            var description = wcsCoverageDescriptions.coverages[0].description;
 
             expect(description).toBe("Generated from GeoTIFF");
         });
 
         it("should have the keywords gebco, WCS, GeoTIFF", function() {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var keywords = wcsDescribeCoverage.coverages[0].keywords;
+            var keywords = wcsCoverageDescriptions.coverages[0].keywords;
 
             expect(keywords[0].value).toBe("gebco");
             expect(keywords[1].value).toBe("WCS");
@@ -80,18 +80,18 @@ define([
         });
 
         it("should have a lonLatEnvelope srs of CRS84", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var lonLatEnvelopSrs = wcsDescribeCoverage.coverages[0].lonLatEnvelope.srsName;
+            var lonLatEnvelopSrs = wcsCoverageDescriptions.coverages[0].lonLatEnvelope.srsName;
 
             expect(lonLatEnvelopSrs).toBe("urn:ogc:def:crs:OGC:1.3:CRS84");
         });
 
         it("should have lonLatEnvelop positions spanning the globe", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
             var error = 1e-9;
 
-            var lonLatEnvelop = wcsDescribeCoverage.coverages[0].lonLatEnvelope;
+            var lonLatEnvelop = wcsCoverageDescriptions.coverages[0].lonLatEnvelope;
 
             expect(lonLatEnvelop.pos[0][0]).toBeCloseTo(-180.0, error);
             expect(lonLatEnvelop.pos[0][1]).toBeCloseTo(-90.0, error);
@@ -100,10 +100,10 @@ define([
         });
 
         it("should show support for the EPSG:4326 CRS", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var supportedRequestCrs = wcsDescribeCoverage.coverages[0].supportedCrs.requests[0];
-            var supportedResponseCrs = wcsDescribeCoverage.coverages[0].supportedCrs.responses[0];
+            var supportedRequestCrs = wcsCoverageDescriptions.coverages[0].supportedCrs.requests[0];
+            var supportedResponseCrs = wcsCoverageDescriptions.coverages[0].supportedCrs.responses[0];
 
             expect(supportedRequestCrs).toBe("EPSG:4326");
             expect(supportedResponseCrs).toBe("EPSG:4326");
@@ -112,25 +112,25 @@ define([
         describe("Supported Formats", function () {
 
             it("should have 12 supported formats", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var supportedFormatsCount = wcsDescribeCoverage.coverages[0].supportedFormats.formats.length;
+                var supportedFormatsCount = wcsCoverageDescriptions.coverages[0].supportedFormats.formats.length;
 
                 expect(supportedFormatsCount).toBe(12);
             });
 
             it("should show a native format of GeoTIFF", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var nativeFormat = wcsDescribeCoverage.coverages[0].supportedFormats.nativeFormat;
+                var nativeFormat = wcsCoverageDescriptions.coverages[0].supportedFormats.nativeFormat;
 
                 expect(nativeFormat).toBe("GeoTIFF");
             });
 
             it("should have support for GeoPackage (tiles)", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var formatSupported = wcsDescribeCoverage.coverages[0].supportedFormats.formats[3];
+                var formatSupported = wcsCoverageDescriptions.coverages[0].supportedFormats.formats[3];
 
                 expect(formatSupported).toBe("GeoPackage (tiles)");
             });
@@ -139,25 +139,25 @@ define([
         describe("Supported Interpolations", function () {
             
             it("should have three supported interpolation methods", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var numberOfSupportedInterpolationMethods = wcsDescribeCoverage.coverages[0].supportedInterpolations.methods.length;
+                var numberOfSupportedInterpolationMethods = wcsCoverageDescriptions.coverages[0].supportedInterpolations.methods.length;
 
                 expect(numberOfSupportedInterpolationMethods).toBe(3);
             });
 
             it("should show a default nearest neighbor interpolation method", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var defaultInterpolation = wcsDescribeCoverage.coverages[0].supportedInterpolations.default;
+                var defaultInterpolation = wcsCoverageDescriptions.coverages[0].supportedInterpolations.default;
 
                 expect(defaultInterpolation).toBe("nearest neighbor");
             });
 
             it("should support bilinear interpolation", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var bilinearInterpolationMethod = wcsDescribeCoverage.coverages[0].supportedInterpolations.methods[1];
+                var bilinearInterpolationMethod = wcsCoverageDescriptions.coverages[0].supportedInterpolations.methods[1];
 
                 expect(bilinearInterpolationMethod).toBe("bilinear");
             });
@@ -166,18 +166,18 @@ define([
         describe("Spatial Domain Set", function () {
 
             it("Should have an envelope with an EPSG:4326 srs name", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var envelopSrsName = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.envelope.srsName;
+                var envelopSrsName = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.envelope.srsName;
 
                 expect(envelopSrsName).toBe("EPSG:4326");
             });
 
             it("Should have an envelope which spans the entire globe", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
                 var error = 1e-9;
 
-                var domainEnvelope = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.envelope.pos;
+                var domainEnvelope = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.envelope.pos;
 
                 expect(domainEnvelope[0][0]).toBeCloseTo(-180.0, error);
                 expect(domainEnvelope[0][1]).toBeCloseTo(-90.0, error);
@@ -186,54 +186,54 @@ define([
             });
 
             it("should have the correct axis names of x and y", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var axisNames = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.axisNames;
+                var axisNames = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.axisNames;
 
                 expect(axisNames[0]).toBe("x");
                 expect(axisNames[1]).toBe("y");
             });
 
             it("should have an origin of -179.99583333333334 89.99583333333334", function() {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var pos = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.origin.pos.pos;
+                var pos = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.origin.pos.pos;
 
                 expect(pos[0]).toBeCloseTo(-179.99583333333334, 0.000001);
                 expect(pos[1]).toBeCloseTo(89.99583333333334, 0.000001);
             });
 
             it("should have a low grid envelope of 0, 0", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var lowEnvelope = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.limits.low;
+                var lowEnvelope = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.limits.low;
 
                 expect(lowEnvelope[0]).toBe("0");
                 expect(lowEnvelope[1]).toBe("0");
             });
 
             it("should have a high grid envelope of 43199, 21599", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var highEnvelope = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.limits.high;
+                var highEnvelope = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.limits.high;
 
                 expect(highEnvelope[0]).toBe("43199");
                 expect(highEnvelope[1]).toBe("21599");
             });
 
             it("should have offset vector values of 0.0 0.008333333333333333 for the first offset", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var values = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.offsetVector[0].values;
+                var values = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.offsetVector[0].values;
 
                 expect(values[0]).toBeCloseTo(0, 0.000001);
                 expect(values[1]).toBeCloseTo(0.008333333333333333, 0.0000001);
             });
 
             it("should have offset vector values of -0.008333333333333333 0.0 for the second offset", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var values = wcsDescribeCoverage.coverages[0].domainSet.spatialDomain.rectifiedGrid.offsetVector[1].values;
+                var values = wcsCoverageDescriptions.coverages[0].domainSet.spatialDomain.rectifiedGrid.offsetVector[1].values;
 
                 expect(values[0]).toBeCloseTo(-0.008333333333333333, 0.0000001);
                 expect(values[1]).toBeCloseTo(0, 0.000001);
@@ -243,33 +243,33 @@ define([
         describe("Range Set", function () {
 
             it("should have a range set name gebco", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var rangeSetName = wcsDescribeCoverage.coverages[0].rangeSet.name;
+                var rangeSetName = wcsCoverageDescriptions.coverages[0].rangeSet.name;
 
                 expect(rangeSetName).toBe("gebco");
             });
 
             it ("should have a range set label gebco", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var rangeSetLabel = wcsDescribeCoverage.coverages[0].rangeSet.label;
+                var rangeSetLabel = wcsCoverageDescriptions.coverages[0].rangeSet.label;
 
                 expect(rangeSetLabel).toBe("gebco");
             });
 
             it("should have a range set axis description name: Band", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var rangeSetAxisName = wcsDescribeCoverage.coverages[0].rangeSet.axisDescriptions[0].name;
+                var rangeSetAxisName = wcsCoverageDescriptions.coverages[0].rangeSet.axisDescriptions[0].name;
 
                 expect(rangeSetAxisName).toBe("Band");
             });
 
             it("should have a range set axis description label: Band", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var rangeSetAxisLabel = wcsDescribeCoverage.coverages[0].rangeSet.axisDescriptions[0].label;
+                var rangeSetAxisLabel = wcsCoverageDescriptions.coverages[0].rangeSet.axisDescriptions[0].label;
 
                 expect(rangeSetAxisLabel).toBe("Band");
             });
@@ -297,9 +297,9 @@ define([
         });
 
         it("should match the coverage id testing__gebco", function () {
-            var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+            var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-            var name = wcsDescribeCoverage.coverages[0].coverageId;
+            var name = wcsCoverageDescriptions.coverages[0].coverageId;
 
             expect(name).toBe("testing__gebco");
         });
@@ -307,72 +307,72 @@ define([
         describe("Domain Set", function () {
 
             it("should have the correct gml:id of grid00__testing__gebco", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var gmlDomainSetId = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.id;
+                var gmlDomainSetId = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.id;
 
                 expect(gmlDomainSetId).toBe("grid00__testing__gebco");
             });
 
             it("should have the correct axis labels of i and j", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var axisLabels = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.axisLabels;
+                var axisLabels = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.axisLabels;
 
                 expect(axisLabels[0]).toBe("i");
                 expect(axisLabels[1]).toBe("j");
             });
 
             it("should have an origin of 89.99583333333334 -179.99583333333334", function() {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var pos = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.origin.point.pos.pos;
+                var pos = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.origin.point.pos.pos;
 
                 expect(pos[0]).toBeCloseTo(89.99583333333334, 0.000001);
                 expect(pos[1]).toBeCloseTo(-179.99583333333334, 0.000001);
             });
 
             it("should have a low grid envelope of 0, 0", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var lowEnvelope = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.limits.low;
+                var lowEnvelope = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.limits.low;
 
                 expect(lowEnvelope[0]).toBe("0");
                 expect(lowEnvelope[1]).toBe("0");
             });
 
             it("should have a high grid envelope of 43199, 21599", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var highEnvelope = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.limits.high;
+                var highEnvelope = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.limits.high;
 
                 expect(highEnvelope[0]).toBe("43199");
                 expect(highEnvelope[1]).toBe("21599");
             });
 
             it("should have an offset vector srsName of 4326 for the first and second offsets", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var offsetSrsOne = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.offsetVector[0].srsName;
-                var offsetSrsTwo = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.offsetVector[1].srsName;
+                var offsetSrsOne = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.offsetVector[0].srsName;
+                var offsetSrsTwo = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.offsetVector[1].srsName;
 
                 expect(offsetSrsOne).toBe("http://www.opengis.net/def/crs/EPSG/0/4326");
                 expect(offsetSrsTwo).toBe("http://www.opengis.net/def/crs/EPSG/0/4326");
             });
 
             it("should have offset vector values of 0.0 0.008333333333333333 for the first offset", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var values = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.offsetVector[0].values;
+                var values = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.offsetVector[0].values;
 
                 expect(values[0]).toBeCloseTo(0, 0.000001);
                 expect(values[1]).toBeCloseTo(0.008333333333333333, 0.0000001);
             });
 
             it("should have offset vector values of -0.008333333333333333 0.0 for the second offset", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var values = wcsDescribeCoverage.coverages[0].domainSet.rectifiedGrid.offsetVector[1].values;
+                var values = wcsCoverageDescriptions.coverages[0].domainSet.rectifiedGrid.offsetVector[1].values;
 
                 expect(values[0]).toBeCloseTo(-0.008333333333333333, 0.0000001);
                 expect(values[1]).toBeCloseTo(0, 0.000001);
@@ -383,52 +383,52 @@ define([
         describe("BoundedBy", function () {
 
             it("should have a bounded by envelope srs name of http://www.opengis.net/def/crs/EPSG/0/4326", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedBySrsName = wcsDescribeCoverage.coverages[0].boundedBy.envelope.srsName;
+                var boundedBySrsName = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.srsName;
 
                 expect(boundedBySrsName).toBe("http://www.opengis.net/def/crs/EPSG/0/4326");
             });
 
             it("should have a bounded by envelope axis labels of Lat and Lon", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedByAxisLabels = wcsDescribeCoverage.coverages[0].boundedBy.envelope.axisLabels;
+                var boundedByAxisLabels = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.axisLabels;
 
                 expect(boundedByAxisLabels[0]).toBe("Lat");
                 expect(boundedByAxisLabels[1]).toBe("Long");
             });
 
             it("should have a bounded by envelope uom labels of Deg and Deg", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedByUomLabels = wcsDescribeCoverage.coverages[0].boundedBy.envelope.uomLabels;
+                var boundedByUomLabels = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.uomLabels;
 
                 expect(boundedByUomLabels[0]).toBe("Deg");
                 expect(boundedByUomLabels[1]).toBe("Deg");
             });
 
             it("should have a bounded by envelope srs dimension of 2", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedBySrsDimension = wcsDescribeCoverage.coverages[0].boundedBy.envelope.srsDimension;
+                var boundedBySrsDimension = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.srsDimension;
 
                 expect(boundedBySrsDimension).toBe(2);
             });
 
             it("should have a bounded by envelope lower corner of -90.0 and -180.0", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedByLowerCorner = wcsDescribeCoverage.coverages[0].boundedBy.envelope.lower;
+                var boundedByLowerCorner = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.lower;
 
                 expect(boundedByLowerCorner[0]).toBeCloseTo(-90.0, 0.000001);
                 expect(boundedByLowerCorner[1]).toBeCloseTo(-180.0, 0.000001);
             });
 
             it("should have a bounded by envelope upper corner of 90.0 and 180.0", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var boundedByUpperCorner = wcsDescribeCoverage.coverages[0].boundedBy.envelope.upper;
+                var boundedByUpperCorner = wcsCoverageDescriptions.coverages[0].boundedBy.envelope.upper;
 
                 expect(boundedByUpperCorner[0]).toBeCloseTo(90.0, 0.000001);
                 expect(boundedByUpperCorner[1]).toBeCloseTo(180.0, 0.000001);
@@ -438,17 +438,17 @@ define([
         describe("Service Parameters", function () {
 
             it("should have a subtype of RectifiedGridCoverage", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var serviceParameterSubtype = wcsDescribeCoverage.coverages[0].serviceParameters.coverageSubtype;
+                var serviceParameterSubtype = wcsCoverageDescriptions.coverages[0].serviceParameters.coverageSubtype;
 
                 expect(serviceParameterSubtype).toBe("RectifiedGridCoverage");
             });
 
             it("should have a native format of image/tiff", function () {
-                var wcsDescribeCoverage = new WcsDescribeCoverage(xmlDom);
+                var wcsCoverageDescriptions = new WcsCoverageDescriptions(xmlDom);
 
-                var serviceParameterNativeFormat = wcsDescribeCoverage.coverages[0].serviceParameters.nativeFormat;
+                var serviceParameterNativeFormat = wcsCoverageDescriptions.coverages[0].serviceParameters.nativeFormat;
 
                 expect(serviceParameterNativeFormat).toBe("image/tiff");
             });


### PR DESCRIPTION
### Description of the Change

This pr changes the WcsDescribeCoverage class to WcsCoverageDescriptions to match the XML naming of the element.

My work in the wcs-wcscoverage branch has grown too big. This is one of several upcoming prs which will break up the work.