### PR TITLE
TiledElevationCoverage config-based construction 

### DIFF
--- a/src/globe/AsterV2ElevationCoverage.js
+++ b/src/globe/AsterV2ElevationCoverage.js
@@ -36,15 +36,21 @@ define([
          * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
          */
         var AsterV2ElevationCoverage = function () {
-            TiledElevationCoverage.call(this,
-                new Sector(-83.0001, 83.0001, -180, 180), new Location(45, 45), 11, "application/bil16",
-                "AsterV2Elevations256", 256, 256, 0.000277777777778);
+            TiledElevationCoverage.call(this, {
+                coverageSector: new Sector(-83.0001, 83.0001, -180, 180),
+                resolution: 0.000277777777778,
+                retrievalImageFormat: "application/bil16",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 11,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "AsterV2Elevations256",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "aster_v2", "", "1.3.0")
+            });
 
             this.displayName = "ASTER V2 Earth Elevation Coverage";
-            this.minElevation = -11000;
-            this.maxElevation = 8850;
-            this.pixelIsPoint = false;
-            this.urlBuilder = new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "aster_v2", "", "1.3.0");
         };
 
         AsterV2ElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);

--- a/src/globe/GebcoElevationCoverage.js
+++ b/src/globe/GebcoElevationCoverage.js
@@ -36,15 +36,21 @@ define([
          * @classdesc Provides elevations for Earth. Elevations are drawn from the NASA WorldWind elevation service.
          */
         var GebcoElevationCoverage = function () {
-            TiledElevationCoverage.call(this,
-                Sector.FULL_SPHERE, new Location(45, 45), 6, "application/bil16",
-                "GebcoElevations256", 256, 256, 0.008333333333333);
+            TiledElevationCoverage.call(this, {
+                coverageSector: Sector.FULL_SPHERE,
+                resolution: 0.008333333333333,
+                retrievalImageFormat: "application/bil16",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 6,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "GebcoElevations256",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "GEBCO", "", "1.3.0")
+            });
 
             this.displayName = "GEBCO Earth Elevation Coverage";
-            this.minElevation = -11000;
-            this.maxElevation = 8850;
-            this.pixelIsPoint = false;
-            this.urlBuilder = new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "GEBCO", "", "1.3.0");
         };
 
         GebcoElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);

--- a/src/globe/UsgsNedElevationCoverage.js
+++ b/src/globe/UsgsNedElevationCoverage.js
@@ -38,15 +38,21 @@ define([
         var UsgsNedElevationCoverage = function () {
             // CONUS Extent: (-124.848974, 24.396308) - (-66.885444, 49.384358)
             // TODO: Expand this extent to cover HI when the server NO_DATA value issue is resolved.
-            TiledElevationCoverage.call(this,
-                new Sector(24.396308, 49.384358, -124.848974, -66.885444), new Location(45, 45), 12, "application/bil16",
-                "UsgsNedElevations256", 256, 256, 0.000092592592593);
+            TiledElevationCoverage.call(this, {
+                coverageSector: new Sector(24.396308, 49.384358, -124.848974, -66.885444),
+                resolution: 0.000092592592593,
+                retrievalImageFormat: "application/bil16",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 12,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "UsgsNedElevations256",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "USGS-NED", "", "1.3.0")
+            });
 
             this.displayName = "USGS NED Earth Elevation Coverage";
-            this.minElevation = -11000;
-            this.maxElevation = 8850;
-            this.pixelIsPoint = false;
-            this.urlBuilder = new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "USGS-NED", "", "1.3.0");
         };
 
         UsgsNedElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);

--- a/src/globe/UsgsNedHiElevationCoverage.js
+++ b/src/globe/UsgsNedHiElevationCoverage.js
@@ -38,15 +38,21 @@ define([
         var UsgsNedHiElevationCoverage = function () {
             // Hawaii Extent: (-178.443593, 18.865460) - (-154.755792, 28.517269)
             // TODO: Remove this class when the server NO_DATA value issue is resolved.
-            TiledElevationCoverage.call(this,
-                new Sector(18.865460, 28.517269, -178.443593, -154.755792), new Location(45, 45), 12, "application/bil16",
-                "UsgsNedHiElevations256", 256, 256, 0.000092592592593);
+            TiledElevationCoverage.call(this, {
+                coverageSector: new Sector(18.865460, 28.517269, -178.443593, -154.755792),
+                resolution: 0.000092592592593,
+                retrievalImageFormat: "application/bil16",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 12,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "UsgsNedHiElevations256",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "USGS-NED", "", "1.3.0")
+            });
 
             this.displayName = "USGS NED Hawaii Elevation Coverage";
-            this.minElevation = -11000;
-            this.maxElevation = 8850;
-            this.pixelIsPoint = false;
-            this.urlBuilder = new WmsUrlBuilder("https://worldwind26.arc.nasa.gov/elev", "USGS-NED", "", "1.3.0");
         };
 
         UsgsNedHiElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);

--- a/src/globe/WcsEarthElevationCoverage.js
+++ b/src/globe/WcsEarthElevationCoverage.js
@@ -37,16 +37,22 @@ define([
          * @deprecated
          */
         var WcsEarthElevationCoverage = function () {
-            TiledElevationCoverage.call(this,
-                Sector.FULL_SPHERE, new Location(45, 45), 12, "image/tiff", "EarthElevations256", 256, 256, 900);
+            TiledElevationCoverage.call(this, {
+                coverageSector: Sector.FULL_SPHERE,
+                resolution: 900,
+                retrievalImageFormat: "image/tiff",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 12,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "EarthElevations256",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new WcsTileUrlBuilder("https://worldwind26.arc.nasa.gov/wms2",
+                    "NASA_SRTM30_900m_Tiled", "1.0.0")
+            });
 
             this.displayName = "WCS Earth Elevation Coverage";
-            this.minElevation = -11000; // Depth of Marianas Trench, in meters
-            this.maxElevation = 8850; // Height of Mt. Everest
-            this.pixelIsPoint = false; // WorldWind WMS elevation layers return pixel-as-area images
-
-            this.urlBuilder = new WcsTileUrlBuilder("https://worldwind26.arc.nasa.gov/wms2",
-                "NASA_SRTM30_900m_Tiled", "1.0.0");
         };
 
         WcsEarthElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);

--- a/src/util/Logger.js
+++ b/src/util/Logger.js
@@ -108,6 +108,7 @@ define(function () {
             missingBoundaries: "The specified boundaries array is null or undefined.",
             missingBuffer: "The specified buffer descriptor is null or undefined.",
             missingColor: "The specified color is null or undefined.",
+            missingConfig: "The specified config is null or undefined.",
             missingDc: "The specified draw context is null or undefined.",
             missingDomElement: "The specified DOM element is null or undefined.",
             missingEntry: "The specified entry is null or undefined.",

--- a/test/globe/ElevationModel.test.js
+++ b/test/globe/ElevationModel.test.js
@@ -23,12 +23,20 @@ define([
     describe("ElevationModel tests", function () {
 
         var MockCoverage = function (resolution, minElevation, maxElevation) {
-            TiledElevationCoverage.call(this,
-                Sector.FULL_SPHERE, new Location(45, 45), 1, "application/bil16", "MockElevations256", 256, 256, resolution);
+            TiledElevationCoverage.call(this, {
+                coverageSector: Sector.FULL_SPHERE,
+                resolution: resolution,
+                retrievalImageFormat: "application/bil16",
+                levelZeroDelta: new Location(45, 45),
+                numLevels: 1,
+                tileWidth: 256,
+                tileHeight: 256,
+                cachePath: "MockElevations256",
+                minElevation: minElevation ? minElevation : -11000,
+                maxElevation: maxElevation ? maxElevation : 8850
+            });
 
             this.displayName = "Mock Elevation Coverage";
-            this.minElevation = minElevation ? minElevation : -11000;
-            this.maxElevation = maxElevation ? maxElevation : 8850;
         };
 
         MockCoverage.prototype = Object.create(TiledElevationCoverage.prototype);


### PR DESCRIPTION
Modified TiledElevationCoverage to enable construction via configuration object. This enables loose coupling between a WebCoverageService specifying the configuration, and the scene component that consumes the configuration (TiledElevationCoverage). This is the first of several changes that streamlines TiledElevationCoverage construction.

This change knowingly breaks backward compatibility. The class TiledElevationCoverage is new since 0.9.0. While we could argue that it should be possible to port 0.9.0 ElevationModel construction to TiledElevationCoverage, as the constructors currently appear very similar, they are fundamentally different. Additionally, the opportunity to improve the elevation coverage interface oughtweighs the benefit we might gain by making it easy to port old ElevationModel code to TiledElevationCoverage.

Relates to #486