### PR TITLE
Updated the Standalone example elevation coverage

### DIFF
--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -46,9 +46,9 @@ imagery, the Landsat imagery and the DTED0 elevations in its Earth directory.
         var wwd = new WorldWind.WorldWindow("canvasOne");
 
         // Use a REST elevation coverage rather than the defaults.
-        var dted0Coverage = new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0");
+        var dted0 = new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0");
         wwd.globe.elevationModel.removeAllCoverages();
-        wwd.globe.elevationModel.addCoverage(dted0Coverage);
+        wwd.globe.elevationModel.addCoverage(dted0);
 
         // Add the REST Blue Marble layer that retrieves imagery from local standalone data.
         var blueMarble = new WorldWind.BMNGRestLayer(null, "../standalonedata/Earth/BlueMarble256/");

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -46,8 +46,9 @@ imagery, the Landsat imagery and the DTED0 elevations in its Earth directory.
         var wwd = new WorldWind.WorldWindow("canvasOne");
 
         // Use a REST elevation coverage rather than the defaults.
+        var dted0Coverage = new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0");
         wwd.globe.elevationModel.removeAllCoverages();
-        wwd.globe.elevationModel.addCoverage(new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0"));
+        wwd.globe.elevationModel.addCoverage(dted0Coverage);
 
         // Add the REST Blue Marble layer that retrieves imagery from local standalone data.
         var blueMarble = new WorldWind.BMNGRestLayer(null, "../standalonedata/Earth/BlueMarble256/");

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -42,10 +42,12 @@ imagery, the Landsat imagery and the DTED0 elevations in its Earth directory.
     function eventWindowLoaded() {
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
-        // Create a WorldWindow for the canvas. Use a REST elevation model rather than the default.
-        var elevationModel = new WorldWind.ElevationModel();
-        elevationModel.addCoverage(new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0", "DTED 0", 0.008333333333333));
-        var wwd = new WorldWind.WorldWindow("canvasOne", elevationModel);
+        // Create a WorldWindow for the canvas.
+        var wwd = new WorldWind.WorldWindow("canvasOne");
+
+        // Use a REST elevation coverage rather than the defaults.
+        wwd.globe.elevationModel.removeAllCoverages();
+        wwd.globe.elevationModel.addCoverage(new WorldWind.EarthRestElevationCoverage(null, "../standalonedata/Earth/DTED0"));
 
         // Add the REST Blue Marble layer that retrieves imagery from local standalone data.
         var blueMarble = new WorldWind.BMNGRestLayer(null, "../standalonedata/Earth/BlueMarble256/");

--- a/src/globe/EarthRestElevationCoverage.js
+++ b/src/globe/EarthRestElevationCoverage.js
@@ -17,38 +17,47 @@
  * @exports EarthRestElevationCoverage
  */
 define([
+        '../util/LevelSet',
         '../geom/Location',
         '../geom/Sector',
         '../util/LevelRowColumnUrlBuilder',
         '../globe/TiledElevationCoverage'
     ],
-    function (Location,
+    function (LevelSet,
+              Location,
               Sector,
               LevelRowColumnUrlBuilder,
               TiledElevationCoverage) {
         "use strict";
 
-        ///**
-        // * Constructs an elevation coverage for Earth using a REST interface to retrieve the elevations from the server.
-        // * @alias EarthRestElevationCoverage
-        // * @constructor
-        // * @classdesc Represents an Earth elevation coverage spanning the globe and using a REST interface to retrieve
-        // * the elevations from the server.
-        // * See [LevelRowColumnUrlBuilder]{@link LevelRowColumnUrlBuilder} for a description of the REST interface.
-        // * @param {String} serverAddress The server address of the tile service. May be null, in which case the
-        // * current origin is used (see <code>window.location</code>.
-        // * @param {String} pathToData The path to the data directory relative to the specified server address.
-        // * May be null, in which case the server address is assumed to be the full path to the data directory.
-        // * @param {String} displayName The display name to associate with this elevation coverage.
-        // */
-        var EarthRestElevationCoverage = function (serverAddress, pathToData, displayName, resolution) {
-            TiledElevationCoverage.call(this,
-                Sector.FULL_SPHERE, new Location(60, 60), 5, "application/bil16", "EarthElevations", 512, 512, resolution);
+        /**
+         * Constructs an elevation coverage for Earth using a REST interface to retrieve the elevations from the server.
+         * @alias EarthRestElevationCoverage
+         * @constructor
+         * @classdesc Represents an Earth elevation coverage spanning the globe and using a REST interface to retrieve
+         * the elevations from the server.
+         * See [LevelRowColumnUrlBuilder]{@link LevelRowColumnUrlBuilder} for a description of the REST interface.
+         * @param {String} serverAddress The server address of the tile service. May be null, in which case the
+         * current origin is used (see <code>window.location</code>.
+         * @param {String} pathToData The path to the data directory relative to the specified server address.
+         * May be null, in which case the server address is assumed to be the full path to the data directory.
+         * @param {String} displayName The display name to associate with this elevation coverage.
+         */
+        var EarthRestElevationCoverage = function (serverAddress, pathToData, displayName) {
+            TiledElevationCoverage.call(this, {
+                coverageSector: Sector.FULL_SPHERE,
+                resolution: 0.00732421875,
+                retrievalImageFormat: "application/bil16",
+                minElevation: -11000,
+                maxElevation: 8850,
+                urlBuilder: new LevelRowColumnUrlBuilder(serverAddress, pathToData)
+            });
 
-            this.displayName = displayName;
-            this.minElevation = -11000; // Depth of Marianas Trench, in meters
-            this.maxElevation = 8850; // Height of Mt. Everest
-            this.urlBuilder = new LevelRowColumnUrlBuilder(serverAddress, pathToData);
+            this.displayName = displayName || "Earth Elevations";
+
+            // Override the default computed LevelSet. EarthRestElevationCoverage accesses a fixed set of tiles with
+            // a 60x60 top level tile delta, 5 levels, and tile dimensions of 512x512 pixels.
+            this.levels = new LevelSet(Sector.FULL_SPHERE, new Location(60, 60), 5, 512, 512);
         };
 
         EarthRestElevationCoverage.prototype = Object.create(TiledElevationCoverage.prototype);


### PR DESCRIPTION
EarthRestElevationCoverage, the coverage used by Standalone.html, was out of date after recent changes to TiledElevationCoverage. Updated this coverage implementation to correctly retrieve standalone elevation tiles.