### PR TITLE
Feature/elevationsforgrid resolution

### DIFF
--- a/src/globe/ElevationCoverage.js
+++ b/src/globe/ElevationCoverage.js
@@ -139,14 +139,12 @@ define(['../error/ArgumentError',
          * @param {Sector} sector The sector for which to determine the elevations.
          * @param {Number} numLat The number of latitudinal sample locations within the sector.
          * @param {Number} numLon The number of longitudinal sample locations within the sector.
-         * @param {Number} targetResolution The desired elevation resolution, in degrees. (To compute degrees from
-         * meters, divide the number of meters by the globe's radius to obtain radians and convert the result to degrees.)
          * @param {Number[]} result An array in which to return the requested elevations.
          * @returns {Boolean} true if the result array was completely filled with elevation data, false otherwise.
          * @throws {ArgumentError} If the specified sector or result array is null or undefined, or if either of the
          * specified numLat or numLon values is less than one.
          */
-        ElevationCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, targetResolution, result) {
+        ElevationCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, result) {
             if (!sector) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "ElevationCoverage", "elevationsForGrid", "missingSector"));

--- a/src/globe/ElevationModel.js
+++ b/src/globe/ElevationModel.js
@@ -325,7 +325,7 @@ define(['../error/ArgumentError',
             for (i = n - 1; !resultFilled && i >= 0; i--) {
                 var coverage = this.coverages[i];
                 if (coverage.enabled && coverage.coverageSector.intersects(sector)) {
-                    resultFilled = coverage.elevationsForGrid(sector, numLat, numLon, targetResolution, result);
+                    resultFilled = coverage.elevationsForGrid(sector, numLat, numLon, result);
                     if (resultFilled) {
                         resolution = coverage.resolution;
                     }

--- a/src/globe/TiledElevationCoverage.js
+++ b/src/globe/TiledElevationCoverage.js
@@ -251,7 +251,7 @@ define(['../util/AbsentResourceList',
         };
 
         // Documented in super class
-        TiledElevationCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, targetResolution, result) {
+        TiledElevationCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, result) {
             if (!sector) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "TiledElevationCoverage", "elevationsForGrid", "missingSector"));
@@ -263,17 +263,8 @@ define(['../util/AbsentResourceList',
                         "The specified number of latitudinal or longitudinal positions is less than one."));
             }
 
-            if (!targetResolution) {
-                throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "TiledElevationCoverage", "elevationsForGrid", "missingTargetResolution"));
-            }
-
-            if (!result) {
-                throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "TiledElevationCoverage", "elevationsForGrid", "missingResult"));
-            }
-
-            var level = this.levels.levelForTexelSize(targetResolution * Angle.DEGREES_TO_RADIANS);
+            var gridResolution = sector.deltaLatitude() / (numLat - 1) * Angle.DEGREES_TO_RADIANS;
+            var level = this.levels.levelForTexelSize(gridResolution);
             if (this.pixelIsPoint) {
                 return this.pointElevationsForGrid(sector, numLat, numLon, level, result);
             } else {

--- a/test/globe/ElevationModel.test.js
+++ b/test/globe/ElevationModel.test.js
@@ -55,7 +55,7 @@ define([
             return this.maxElevation;
         };
 
-        MockCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, targetResolution, result) {
+        MockCoverage.prototype.elevationsForGrid = function (sector, numLat, numLon, result) {
             for (var i = 0, n = result.length; i < n; i++) {
                 result[i] = this.maxElevation;
             }


### PR DESCRIPTION
Clarifies ElevationCoverage's elevationsForGrid interface by removing the unnecessary and potentially harmful targetResolution argument.

The function elevationsForGrid derived from the original ElevationModel, which used targetResolution to select a level in the model's tile pyramid. Since implementing composable elevations (#575), this function appears in both ElevationModel and ElevationCoverage, but serves a different purpose in each.

The argument list to elevationsForGrid need not be the same, and in fact should not be the same. ElevationModel needs targetResolution to let the caller influence which coverage is chosen to fulfil the request. ElevationCoverage does not need targetResolution. Allowing the caller to specify a resolution to ElevationCoverage is unnecessary and potentially dangerous. The grid itself provides an implicit resolution the coverage can use to select a level. Letting the caller override that resolution risks the caller unknowingly attempting more data than can can be downloaded and managed in memory.

Relates to #422