### PR TITLE
Replacement of Bing logo image credit for a ScreenImage

### DIFF
--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -18,14 +18,22 @@
  */
 define([
         '../geom/Angle',
+        '../util/Color',
         '../geom/Location',
+        '../util/Offset',
+        '../shapes/ScreenImage',
         '../geom/Sector',
-        '../layer/MercatorTiledImageLayer'
+        '../layer/MercatorTiledImageLayer',
+        '../layer/ViewControlsLayer'
     ],
     function (Angle,
+              Color,
               Location,
+              Offset,
+              ScreenImage,
               Sector,
-              MercatorTiledImageLayer) {
+              MercatorTiledImageLayer,
+              ViewControlsLayer) {
         "use strict";
 
         /**
@@ -35,11 +43,17 @@ define([
          * @augments MercatorTiledImageLayer
          * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
          * independently but as a base layer for subclasses.
+         * @param (logoOffset) Offset Optional offset indicating the Bing logo attribution placement on the screen.
+         * @param (logoPosition) String Optional positioning of the Bing logo in the left canvas side, either top or
+         * bottom of the canvas. Defaults to top.
          * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
          *
          * @param {String} displayName This layer's display name.
          */
-        var BingTiledImageLayer = function (displayName) {
+        var BingTiledImageLayer = function (displayName, logoPosition) {
+
+            var logotypePosition = logoPosition ? logoPosition : "top";
+
             this.imageSize = 256;
 
             MercatorTiledImageLayer.call(this,
@@ -53,15 +67,47 @@ define([
 
             this.detectBlankImages = true;
 
-            this.creditImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+            this.logoImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+
+            this.logo = this.createLogotype();
+
+            this.logoPosition = logotypePosition;
         };
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
+            var canvasWidth = dc.currentGlContext.canvas.clientWidth;
+
+            // Draw Bing logo in selected position.
+            if (this.logoPosition = "top") {
+                // Top left was selected. Draw in top left corner when CoordinatesDisplayLayer is being drawn at the
+                // bottom of the screen
+
+                this.logo.screenOffset.xUnits = WorldWind.OFFSET_FRACTION;
+                this.logo.screenOffset.x = 0;
+                this.logo.screenOffset.yUnits = WorldWind.OFFSET_INSET_PIXELS;
+                this.logo.imageOffset.y = 1;
+                this.logo.imageOffset.x = 0;
+
+                if (canvasWidth >= 650) { // Large canvas, draw logo in upper left corner
+                    this.logo.screenOffset.y = 0;
+                } else { // Medium/Small canvas, offset vertically to avoid cluttering with CoordinatesDisplayLayer
+                    this.logo.screenOffset.y = 21;
+                }
+
+            } else if (this.logoPosition = "bottom") {
+                // Bottom left was selected. Draw in lower left corner when the view controls are not visible, or
+                // right above them when they are.
+                // dc.layers.indexOf("ViewControlsLayer")
+
+            }
+
+
+
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
             if (this.inCurrentFrame) {
-                dc.screenCreditController.addImageCredit(this.creditImage);
+                this.logo.render(dc);
             }
         };
 
@@ -78,6 +124,16 @@ define([
         // Determines the Bing map size for a specified level number.
         BingTiledImageLayer.prototype.mapSizeForLevel = function (levelNumber) {
             return 256 << (levelNumber + 1);
+        };
+
+        BingTiledImageLayer.prototype.createLogotype = function () {
+            var offset = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_FRACTION, 0);
+            var logotype = new ScreenImage(offset, this.logoImage);
+
+            logotype.imageColor = new Color(1, 1, 1, 0.5);
+
+
+            return logotype;
         };
 
         return BingTiledImageLayer;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -89,10 +89,10 @@ define([
         };
 
         BingTiledImageLayer.prototype.createBingLogotype = function () {
-            // Locate Bing logo in the upper left corner
+            // Locate Bing logo in the lower right corner
             var offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
             var logotype = new ScreenImage(offset, this.attributionImage);
-            // Align the logo using as reference point its upper left corner
+            // Align the logo using as reference point its lower right corner
             logotype.imageOffset.y = 0;
             logotype.imageOffset.x = 1;
             // Make logo semi-transparent

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -60,7 +60,7 @@ define([
             this.detectBlankImages = true;
 
             this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
-            // TODO: CORS issues, insecure protocol
+            // TODO: CORS issues, insecure protocol when retrieving logo from web service.
             //this.attributionImage = "http://dev.virtualearth.net/Branding/logo_powered_by.png";
 
             this.attribution = this.createBingLogotype();

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -41,8 +41,8 @@ define([
          * @augments MercatorTiledImageLayer
          * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
          * independently but as a base layer for subclasses.
-         *
          * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
+         * 
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -60,8 +60,6 @@ define([
             this.detectBlankImages = true;
 
             this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
-            // TODO: CORS issues, insecure protocol when retrieving logo from web service.
-            //this.attributionImage = "http://dev.virtualearth.net/Branding/logo_powered_by.png";
 
             this.attribution = this.createBingLogotype();
         };
@@ -71,16 +69,6 @@ define([
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
             if (this.inCurrentFrame) {
-                // Draw Bing attribution in upper right corner. Offset vertically when the coordinates display is placed
-                // at the top of the canvas depending on canvas width, as defined in CanvasDisplayLayer.
-                if (dc.currentGlContext.canvas.clientWidth >= 650) {
-                    // Large canvas, draw attribution in upper left corner.
-                    this.attribution.screenOffset.y = 0;
-                } else {
-                    // Medium/Small canvas, offset vertically to avoid cluttering.
-                    this.attribution.screenOffset.y = 21;
-                }
-
                 this.attribution.render(dc);
             }
         };
@@ -102,11 +90,11 @@ define([
 
         BingTiledImageLayer.prototype.createBingLogotype = function () {
             // Locate Bing logo in the upper left corner
-            var offset = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_INSET_PIXELS, 0);
+            var offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
             var logotype = new ScreenImage(offset, this.attributionImage);
             // Align the logo using as reference point its upper left corner
-            logotype.imageOffset.y = 1;
-            logotype.imageOffset.x = 0;
+            logotype.imageOffset.y = 0;
+            logotype.imageOffset.x = 1;
             // Make logo semi-transparent
             logotype.imageColor = new Color(1, 1, 1, 0.5);
             return logotype;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -42,7 +42,7 @@ define([
          * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
          * independently but as a base layer for subclasses.
          * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
-         * 
+         *
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -92,15 +92,11 @@ define([
             // Locate Bing logo in the lower right corner
             var offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
             var logotype = new ScreenImage(offset, this.attributionImage);
-            // Align the logo using as reference point its lower right corner
+            // Align the logo replicating the alignment given by ScreenCreditsController
             logotype.imageOffset.xUnits = WorldWind.OFFSET_INSET_PIXELS;
             logotype.imageOffset.yUnits = WorldWind.OFFSET_INSET_PIXELS;
-            logotype.imageOffset.x = -10;
+            logotype.imageOffset.x = -5;
             logotype.imageOffset.y = 35;
-            // Position logo with a 5px margin
-            // logotype.screenOffset.xUnits = WorldWind.OFFSET_PIXELS;
-            // logotype.screenOffset.yUnits = WorldWind.OFFSET_PIXELS;
-            //logotype.imageOffset.x = 5;
 
             // Make logo semi-transparent
             logotype.imageColor = new Color(1, 1, 1, 0.5);

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -42,7 +42,6 @@ define([
          * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
          * independently but as a base layer for subclasses.
          * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
-         *
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {
@@ -61,16 +60,29 @@ define([
             this.detectBlankImages = true;
 
             this.logoImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+            // TODO: CORS issues, insecure protocol
+            //this.logoImage = "http://dev.virtualearth.net/Branding/logo_powered_by.png";
 
-            this.logo = this.createLogotype();
+            this.attribution = this.createBingLogotype();
         };
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
+
             if (this.inCurrentFrame) {
-                this.logo.render(dc);
+                // Draw Bing attribution in upper right corner. Offset vertically when the coordinates display is placed
+                // at the top of the canvas depending on canvas width, as defined in CanvasDisplayLayer.
+                if (dc.currentGlContext.canvas.clientWidth >= 650) {
+                    // Large canvas, draw attribution in upper left corner.
+                    this.attribution.screenOffset.y = 0;
+                } else {
+                    // Medium/Small canvas, offset vertically to avoid cluttering.
+                    this.attribution.screenOffset.y = 21;
+                }
+
+                this.attribution.render(dc);
             }
         };
 
@@ -89,13 +101,13 @@ define([
             return 256 << (levelNumber + 1);
         };
 
-        BingTiledImageLayer.prototype.createLogotype = function () {
-            // Locate Bing logo in the lower right corner
-            var offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
+        BingTiledImageLayer.prototype.createBingLogotype = function () {
+            // Locate Bing logo in the upper left corner
+            var offset = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_INSET_PIXELS, 0);
             var logotype = new ScreenImage(offset, this.logoImage);
-            // Align the logo using as reference point its lower right corner
-            logotype.imageOffset.y = 0;
-            logotype.imageOffset.x = 1;
+            // Align the logo using as reference point its upper left corner
+            logotype.imageOffset.y = 1;
+            logotype.imageOffset.x = 0;
             // Make logo semi-transparent
             logotype.imageColor = new Color(1, 1, 1, 0.5);
             return logotype;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -41,11 +41,11 @@ define([
          * @augments MercatorTiledImageLayer
          * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
          * independently but as a base layer for subclasses.
+         *
          * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {
-
             this.imageSize = 256;
 
             MercatorTiledImageLayer.call(this,
@@ -59,9 +59,9 @@ define([
 
             this.detectBlankImages = true;
 
-            this.logoImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+            this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
             // TODO: CORS issues, insecure protocol
-            //this.logoImage = "http://dev.virtualearth.net/Branding/logo_powered_by.png";
+            //this.attributionImage = "http://dev.virtualearth.net/Branding/logo_powered_by.png";
 
             this.attribution = this.createBingLogotype();
         };
@@ -70,7 +70,6 @@ define([
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-
             if (this.inCurrentFrame) {
                 // Draw Bing attribution in upper right corner. Offset vertically when the coordinates display is placed
                 // at the top of the canvas depending on canvas width, as defined in CanvasDisplayLayer.
@@ -104,7 +103,7 @@ define([
         BingTiledImageLayer.prototype.createBingLogotype = function () {
             // Locate Bing logo in the upper left corner
             var offset = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_INSET_PIXELS, 0);
-            var logotype = new ScreenImage(offset, this.logoImage);
+            var logotype = new ScreenImage(offset, this.attributionImage);
             // Align the logo using as reference point its upper left corner
             logotype.imageOffset.y = 1;
             logotype.imageOffset.x = 0;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -93,8 +93,15 @@ define([
             var offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
             var logotype = new ScreenImage(offset, this.attributionImage);
             // Align the logo using as reference point its lower right corner
-            logotype.imageOffset.y = 0;
-            logotype.imageOffset.x = 1;
+            logotype.imageOffset.xUnits = WorldWind.OFFSET_INSET_PIXELS;
+            logotype.imageOffset.yUnits = WorldWind.OFFSET_INSET_PIXELS;
+            logotype.imageOffset.x = -10;
+            logotype.imageOffset.y = 35;
+            // Position logo with a 5px margin
+            // logotype.screenOffset.xUnits = WorldWind.OFFSET_PIXELS;
+            // logotype.screenOffset.yUnits = WorldWind.OFFSET_PIXELS;
+            //logotype.imageOffset.x = 5;
+
             // Make logo semi-transparent
             logotype.imageColor = new Color(1, 1, 1, 0.5);
             return logotype;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -96,7 +96,7 @@ define([
             logotype.imageOffset.xUnits = WorldWind.OFFSET_INSET_PIXELS;
             logotype.imageOffset.yUnits = WorldWind.OFFSET_INSET_PIXELS;
             logotype.imageOffset.x = -5;
-            logotype.imageOffset.y = 35;
+            logotype.imageOffset.y = 36;
 
             // Make logo semi-transparent
             logotype.imageColor = new Color(1, 1, 1, 0.5);


### PR DESCRIPTION
### Description of the Change
Removed image credit usage from Bing's layers in order to replace it with a ScreenImage with the same contents.
Bing seems to be a special case among 3rd party imagery providers in that they require displaying their logo (instead of only string-based attributions) when their imagery is used. With this change we maintain compliance with Bing's TOS while setting the stage to simplify our general handling of attributions by relying only in text-based credits in a future step.

### Benefits
- Maintains compliance with Bing's TOS by displaying their logo when their tiles are displayed in the globe. 
- Enables us to handle credits independently of this logo in order to address credit cluttering and customization.
- Places the logo where screen real estate is available without operlapping other WebWW overlay elements. The logo accommodates itself when coordinates display is moved to the top of the canvas in small screens, utilizing the same resolution criteria as CoordinatesDisplayLayer.

### Potential Drawbacks
- Bing's logo is not retrieved from its web service. This was attempted but the URL provided by Bing's REST service does not allow CORS, plus it's hosted via insecure http. Another source that allowed hotlinking couldn't be found. This still uses our locally hosted Bing logo image file.

- Aesthetic choices on where to put the Bing logo. This can of course be changed after feedback from the team.

### Applicable Issues
Relates to #659.