### PR TITLE
Repositioned view controls, coordinates, and Bing logo overlays

### DIFF
--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -67,7 +67,7 @@ define([
              * @default A value of (WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5) provides a
              * 5px margin inset from the lower right corner of the screen.
              */
-            this.logoPlacement = new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5);
+            this.logoPlacement = new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 20);
 
             /**
              * An {@link Offset} indicating the alignment of the Bing logo relative to the placement position.

--- a/src/layer/CoordinatesDisplayLayer.js
+++ b/src/layer/CoordinatesDisplayLayer.js
@@ -146,9 +146,9 @@ define([
                 canvasWidth = dc.currentGlContext.canvas.clientWidth,
                 x, y, yUnitsScreen, yUnitsText, hideEyeAlt;
 
-            if (canvasWidth > 650) { // large canvas, align the text with bottom center
+            if (canvasWidth > 650) { // large canvas, align the text with bottom center, 20px margin from the bottom
                 x = (canvasWidth / 2) - 50;
-                y = 5;
+                y = 20;
                 yUnitsScreen = WorldWind.OFFSET_PIXELS;
                 yUnitsText = 0;
             } else if (canvasWidth > 400) { // medium canvas, align the text in the top left

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -106,7 +106,7 @@ define([
             /**
              * An {@link Offset} indicating where to place the controls on the screen.
              * @type {Offset}
-             * @default The lower left corner of the window, with a 20px margin from the bottom side of the screen.
+             * @default The lower left corner of the window, with 20px vertical and 5px horizontal margins.
              */
             this.placement = new Offset(WorldWind.OFFSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 20);
 

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -108,7 +108,7 @@ define([
              * @type {Offset}
              * @default The lower left corner of the window, with a 20px margin from the bottom side of the screen.
              */
-            this.placement = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_PIXELS, 20);
+            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 20);
 
             /**
              * An {@link Offset} indicating the alignment of the control collection relative to the

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -106,9 +106,9 @@ define([
             /**
              * An {@link Offset} indicating where to place the controls on the screen.
              * @type {Offset}
-             * @default The lower left corner of the window.
+             * @default The lower left corner of the window, with a 20px margin from the bottom side of the screen.
              */
-            this.placement = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_FRACTION, 0);
+            this.placement = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_PIXELS, 20);
 
             /**
              * An {@link Offset} indicating the alignment of the control collection relative to the


### PR DESCRIPTION
### Description of the Change
Every overlay present in the bottom of the canvas was repositioned with a 20px margin from it. This, in order to reposition screen credits below them as a single line.

### Applicable Issues
Related to #645 