### PR TITLE
Addressed multiple Bing logos rendered on top of another

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -29,6 +29,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         './BasicWorldWindowController',
         './layer/BingAerialLayer',
         './layer/BingAerialWithLabelsLayer',
+        './layer/BingLogoLayer',
         './layer/BingRoadsLayer',
         './layer/BingWMSLayer',
         './layer/BMNGLandsatLayer',
@@ -281,6 +282,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
               BasicWorldWindowController,
               BingAerialLayer,
               BingAerialWithLabelsLayer,
+              BingLogoLayer,
               BingRoadsLayer,
               BingWMSLayer,
               BMNGLandsatLayer,
@@ -755,6 +757,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         WorldWind['BasicWorldWindowController'] = BasicWorldWindowController;
         WorldWind['BingAerialLayer'] = BingAerialLayer;
         WorldWind['BingAerialWithLabelsLayer'] = BingAerialWithLabelsLayer;
+        WorldWind['BingLogoLayer'] = BingLogoLayer;
         WorldWind['BingRoadsLayer'] = BingRoadsLayer;
         WorldWind['BingWMSLayer'] = BingWMSLayer;
         WorldWind['BMNGLandsatLayer'] = BMNGLandsatLayer;

--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -825,6 +825,7 @@ define([
             dc.navigator = this.navigator;
             dc.layers = this.layers.slice();
             dc.layers.push(dc.screenCreditController);
+            dc.layers.push(dc.bingLogoLayer);
             this.computeDrawContext();
             dc.verticalExaggeration = this.verticalExaggeration;
             dc.surfaceOpacity = this.surfaceOpacity;

--- a/src/layer/BingLogoLayer.js
+++ b/src/layer/BingLogoLayer.js
@@ -29,15 +29,14 @@ define([
         "use strict";
 
         /**
-         * Constructs a base Bing layer. This constructor is meant to be called only by subclasses.
-         * @alias BingTiledImageLayer
+         * A Layer that displays the Bing logo.
+         * @alias BingLogoLayer
          * @constructor
-         * @augments MercatorTiledImageLayer
-         * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
-         * independently but as a base layer for subclasses.
-         * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
-         *
-         * @param {String} displayName This layer's display name.
+         * @augments Layer
+         * @classdesc Displays the Bing logo in order to provide attributions to layers with imagery provided by Bing.
+         * Attached to the {@link DrawContext} and added to the {@link WorldWindow} as an 'internal' Layer. It's
+         * disabled by default and meant to be commanded to draw the Bing logo by {@link BingTiledImageLayer}
+         * and its subclasses.
          */
         var BingLogoLayer = function () {
             Layer.call(this, "BingLogoLayer");
@@ -63,7 +62,7 @@ define([
 
             this.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
 
-            // Make Bing logo semi transparent.
+            // Make Bing logo semi-transparent.
             this.attribution.imageColor = new Color(1, 1, 1, 0.5);
         };
 

--- a/src/layer/BingLogoLayer.js
+++ b/src/layer/BingLogoLayer.js
@@ -39,10 +39,12 @@ define([
          *
          * @param {String} displayName This layer's display name.
          */
-        var BingLogoLayer = function (displayName) {
+        var BingLogoLayer = function () {
             Layer.call(this, "BingLogoLayer");
 
             this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+
+            this.enabled = false;
 
             /**
              * An {@link Offset} indicating where to place the Bing logo on the screen.

--- a/src/layer/BingLogoLayer.js
+++ b/src/layer/BingLogoLayer.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015-2017 WorldWind Contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @exports BingLogoLayer
+ */
+define([
+        '../util/Color',
+        '../util/Offset',
+        '../layer/Layer',
+        '../shapes/ScreenImage'
+    ],
+    function (Color,
+              Offset,
+              Layer,
+              ScreenImage) {
+        "use strict";
+
+        /**
+         * Constructs a base Bing layer. This constructor is meant to be called only by subclasses.
+         * @alias BingTiledImageLayer
+         * @constructor
+         * @augments MercatorTiledImageLayer
+         * @classdesc Provides an abstract base layer for Bing imagery. This class is not intended to be constructed
+         * independently but as a base layer for subclasses.
+         * See {@link BingAerialLayer}, {@link BingAerialWithLabelsLayer} and {@link BingRoadsLayer}.
+         *
+         * @param {String} displayName This layer's display name.
+         */
+        var BingLogoLayer = function (displayName) {
+            Layer.call(this, "BingLogoLayer");
+
+            this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
+
+            /**
+             * An {@link Offset} indicating where to place the Bing logo on the screen.
+             * @type {Offset}
+             * @default A value of (WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5) provides a
+             * 5px margin inset from the lower right corner of the screen.
+             */
+            this.logoPlacement = new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5);
+
+            /**
+             * An {@link Offset} indicating the alignment of the Bing logo relative to the placement position.
+             * @type {Offset}
+             * @default Lower right corner of the logo.
+             */
+            this.logoAlignment = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
+
+            this.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
+
+            // Make Bing logo semi transparent.
+            this.attribution.imageColor = new Color(1, 1, 1, 0.5);
+        };
+
+        BingLogoLayer.prototype = Object.create(Layer.prototype);
+
+        BingLogoLayer.prototype.doRender = function (dc) {
+            Layer.prototype.doRender.call(this, dc);
+            this.attribution.screenOffset = this.logoPlacement;
+            this.attribution.imageOffset = this.logoAlignment;
+            this.attribution.render(dc);
+        };
+
+        return BingLogoLayer;
+    }
+)
+;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -18,18 +18,12 @@
  */
 define([
         '../geom/Angle',
-        '../util/Color',
         '../geom/Location',
-        '../util/Offset',
-        '../shapes/ScreenImage',
         '../geom/Sector',
         '../layer/MercatorTiledImageLayer'
     ],
     function (Angle,
-              Color,
               Location,
-              Offset,
-              ScreenImage,
               Sector,
               MercatorTiledImageLayer) {
         "use strict";
@@ -64,7 +58,8 @@ define([
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if(this.inCurrentFrame){
+            // Draw the Bing logo to provide the appropriate attribution
+            if (this.inCurrentFrame) {
                 dc.bingLogoLayer.doRender(dc);
             } else {
                 dc.bingLogoLayer.enabled = false;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -58,39 +58,18 @@ define([
             this.pickEnabled = true;
 
             this.detectBlankImages = true;
-
-            this.attributionImage = WorldWind.configuration.baseUrl + "images/powered-by-bing.png";
-
-            /**
-             * An {@link Offset} indicating where to place the Bing logo on the screen.
-             * @type {Offset}
-             * @default A value of (WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5) provides a
-             * 5px margin inset from the lower right corner of the screen.
-             */
-            this.logoPlacement = new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5);
-
-            /**
-             * An {@link Offset} indicating the alignment of the Bing logo relative to the placement position.
-             * @type {Offset}
-             * @default Lower right corner of the logo.
-             */
-            this.logoAlignment = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
-
-            this.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
-
-            // Make Bing logo semi transparent.
-            this.attribution.imageColor = new Color(1, 1, 1, 0.5);
         };
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if (this.inCurrentFrame) {
-                this.attribution.screenOffset = this.logoPlacement;
-                this.attribution.imageOffset = this.logoAlignment;
-                this.attribution.render(dc);
+            if(this.inCurrentFrame){
+                dc.bingLogoLayer.doRender(dc);
+            } else {
+                dc.bingLogoLayer.enabled = false;
             }
+
         };
 
         // Overridden from TiledImageLayer.

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -146,6 +146,10 @@ define([
              */
             this.screenCreditController = new ScreenCreditController();
 
+            /**
+             * The Layer responsible for displaying the Bing logo alongside Bing's imagery layers.
+             * @type {BingLogoLayer}
+             */
             this.bingLogoLayer = new BingLogoLayer();
 
             /**

--- a/src/render/DrawContext.js
+++ b/src/render/DrawContext.js
@@ -18,6 +18,7 @@
  */
 define([
         '../error/ArgumentError',
+        '../layer/BingLogoLayer',
         '../util/Color',
         '../util/FrameStatistics',
         '../render/FramebufferTexture',
@@ -45,6 +46,7 @@ define([
         '../util/WWMath'
     ],
     function (ArgumentError,
+              BingLogoLayer,
               Color,
               FrameStatistics,
               FramebufferTexture,
@@ -143,6 +145,8 @@ define([
              * @type {ScreenCreditController}
              */
             this.screenCreditController = new ScreenCreditController();
+
+            this.bingLogoLayer = new BingLogoLayer();
 
             /**
              * A shared TextRenderer instance.


### PR DESCRIPTION
### Description of the Change
Previous modification to `BingTiledImageLayer` added a Bing logo `ScreenImage` to it in order to provide imagery attributions  (#661). Inadvertently, this caused every subclass of `BingTiledImageLayer` to draw its own Bing logo when enabled, which resulted in multiple unnecessary logos being drawn in top of another.

After making sure this redrawing wasn't caused by an oversight in `BingTiledImageryLayer.doRender` (e.g. forcing the redraw to be coincident with `DrawContext.timestamp`), other methods were attempted to avoid this needless multiple instancing while maintaining previous architecture. After these attempts failed, the current proposal was drafted: As with every other 2D overlay, the logo is now added as its own layer and removed from `BingTiledImageryLayer` altogether. This way, the logo isn't copied to every subclass of this layer down the prototype chain, which was the cause of the bug.

In a similar manner as with `ScreenCreditController`, the new `BingLogoLayer` is attached to the `DrawContext` and added as an 'internal' layer of sorts by default to the `WorldWindow`. It only gets drawn when `BingTiledImageLayer` (or more appropriately, its subclasses) requests it.

### Why Should This Be In Core?
Solves previous multiple Bing logo bug. 

### Benefits
Besides solving the bug, this maintains the pattern of providing every 2D overlay via a `Layer`. Maintains capability of logo placement customization.

### Potential Drawbacks
This layer is added to the `WorldWindow` in a similar manner to `ScreenCreditController`. I'm not sure if this is the proper pattern to follow. Unlike `ScreenCreditController`, this one is added into the `/src/layer` folder.

### Applicable Issues
Closes #687