### PR TITLE
Avoided drawing of multiple Bing logos using static member

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -949,6 +949,8 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
          *     <li><code>baseUrl</code>: The URL of the directory containing the WorldWind Library and its resources.</li>
          *     <li><code>layerRetrievalQueueSize</code>: The number of concurrent tile requests allowed per layer. The default is 16.</li>
          *     <li><code>coverageRetrievalQueueSize</code>: The number of concurrent tile requests allowed per elevation coverage. The default is 16.</li>
+         *     <li><code>bingLogoPlacement</code>: An {@link Offset} to place a Bing logo attribution. The default is a 5px margin inset from the lower right corner of the screen.</li>
+         *     <li><code>bingLogoAlignment</code>: An {@link Offset} to align the Bing logo relative to its placement position. The default is the lower right corner of the logo.</li>
          * </ul>
          * @type {{gpuCacheSize: number}}
          */
@@ -957,20 +959,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
             baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../'),
             layerRetrievalQueueSize: 16,
             coverageRetrievalQueueSize: 16,
-
-            /**
-             * An {@link Offset} indicating where to place the Bing logo on the screen.
-             * @type {Offset}
-             * @default A value of (WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5) provides a
-             * 5px margin inset from the lower right corner of the screen.
-             */
             bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5),
-
-            /**
-             * An {@link Offset} indicating the alignment of the Bing logo relative to the placement position.
-             * @type {Offset}
-             * @default Lower right corner of the logo.
-             */
             bingLogoAlignment: new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0)
         };
 

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -956,7 +956,22 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
             gpuCacheSize: 250e6,
             baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../'),
             layerRetrievalQueueSize: 16,
-            coverageRetrievalQueueSize: 16
+            coverageRetrievalQueueSize: 16,
+
+            /**
+             * An {@link Offset} indicating where to place the Bing logo on the screen.
+             * @type {Offset}
+             * @default A value of (WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5) provides a
+             * 5px margin inset from the lower right corner of the screen.
+             */
+            bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5),
+
+            /**
+             * An {@link Offset} indicating the alignment of the Bing logo relative to the placement position.
+             * @type {Offset}
+             * @default Lower right corner of the logo.
+             */
+            bingLogoAlignment: new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0)
         };
 
         /**

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -76,25 +76,28 @@ define([
              */
             this.logoAlignment = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
 
-            this.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
-
             // Make Bing logo semi transparent.
-            this.attribution.imageColor = new Color(1, 1, 1, 0.5);
+            //this.attribution.imageColor = new Color(1, 1, 1, 0.5);
+
+            this.logoLastFrameTime = 0;
+
+            BingTiledImageLayer.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
+            BingTiledImageLayer.attribution.imageColor = new Color(1, 1, 1, 0.5);
         };
 
         // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
         // more than one logo at a time.
-        BingTiledImageLayer.logoLastFrameTime = 0;
+        // BingTiledImageLayer.logoLastFrameTime = 0;
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if (this.inCurrentFrame && BingTiledImageLayer.logoLastFrameTime !== dc.timestamp) {
-                this.attribution.screenOffset = this.logoPlacement;
-                this.attribution.imageOffset = this.logoAlignment;
-                this.attribution.render(dc);
-                BingTiledImageLayer.logoLastFrameTime = this.attribution.lastFrameTime;
+            if (this.inCurrentFrame && this.logoLastFrameTime !== dc.timestamp) {
+                BingTiledImageLayer.attribution.screenOffset = this.logoPlacement;
+                BingTiledImageLayer.attribution.imageOffset = this.logoAlignment;
+                BingTiledImageLayer.attribution.render(dc);
+                this.logoLastFrameTime = BingTiledImageLayer.attribution.lastFrameTime;
             }
         };
 

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -82,7 +82,7 @@ define([
             // Store last time the logo was rendered to prevent subclasses from drawing more than one logo at a time.
             BingTiledImageLayer.logoLastFrameTime = 0;
         };
-        
+
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -76,19 +76,13 @@ define([
              */
             this.logoAlignment = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0);
 
-            // Make Bing logo semi transparent.
-            //this.attribution.imageColor = new Color(1, 1, 1, 0.5);
-
-            this.logoLastFrameTime = 0;
-
+            // Set the logo attribution as a "static" member
             BingTiledImageLayer.attribution = new ScreenImage(this.logoPlacement, this.attributionImage);
-            BingTiledImageLayer.attribution.imageColor = new Color(1, 1, 1, 0.5);
+            BingTiledImageLayer.attribution.imageColor = new Color(1, 1, 1, 0.5); // Make Bing logo semi transparent.
+            // Store last time the logo was rendered to prevent subclasses from drawing more than one logo at a time.
+            BingTiledImageLayer.logoLastFrameTime = 0;
         };
-
-        // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
-        // more than one logo at a time.
-        // BingTiledImageLayer.logoLastFrameTime = 0;
-
+        
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -81,18 +81,20 @@ define([
             // Make Bing logo semi transparent.
             this.attribution.imageColor = new Color(1, 1, 1, 0.5);
 
-            // Make logo a static member so a single instance is shared between all subclasses.
-            BingTiledImageLayer.bingLogo = this.attribution;
+            // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
+            // more than one logo at a time.
+            BingTiledImageLayer.lastTimeLogoWasRendered = 0;
         };
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if (this.inCurrentFrame) {
-                BingTiledImageLayer.bingLogo.screenOffset = this.logoPlacement;
-                BingTiledImageLayer.bingLogo.imageOffset = this.logoAlignment;
-                BingTiledImageLayer.bingLogo.render(dc);
+            if (this.inCurrentFrame && BingTiledImageLayer.lastTimeLogoWasRendered !== dc.timestamp) {
+                this.attribution.screenOffset = this.logoPlacement;
+                this.attribution.imageOffset = this.logoAlignment;
+                this.attribution.render(dc);
+                BingTiledImageLayer.lastTimeLogoWasRendered = this.attribution.lastFrameTime;
             }
         };
 

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -80,11 +80,11 @@ define([
 
             // Make Bing logo semi transparent.
             this.attribution.imageColor = new Color(1, 1, 1, 0.5);
-
-            // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
-            // more than one logo at a time.
-            BingTiledImageLayer.lastTimeLogoWasRendered = 0;
         };
+
+        // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
+        // more than one logo at a time.
+        BingTiledImageLayer.lastTimeLogoWasRendered = 0;
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -87,7 +87,7 @@ define([
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if (this.inCurrentFrame && this.logoLastFrameTime !== dc.timestamp) {
+            if (this.inCurrentFrame && BingTiledImageLayer.logoLastFrameTime !== dc.timestamp) {
                 BingTiledImageLayer.attribution.screenOffset = this.logoPlacement;
                 BingTiledImageLayer.attribution.imageOffset = this.logoAlignment;
                 BingTiledImageLayer.attribution.render(dc);

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -91,7 +91,7 @@ define([
                 BingTiledImageLayer.attribution.screenOffset = this.logoPlacement;
                 BingTiledImageLayer.attribution.imageOffset = this.logoAlignment;
                 BingTiledImageLayer.attribution.render(dc);
-                this.logoLastFrameTime = BingTiledImageLayer.attribution.lastFrameTime;
+                BingTiledImageLayer.logoLastFrameTime = BingTiledImageLayer.attribution.lastFrameTime;
             }
         };
 

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -87,9 +87,11 @@ define([
         };
 
         BingTiledImageLayer.prototype.renderLogo = function (dc) {
-            BingTiledImageLayer.logoImage = new ScreenImage(WorldWind.configuration.bingLogoPlacement,
-                WorldWind.configuration.bingLogoUrl);
-            BingTiledImageLayer.logoImage.imageColor = new Color(1, 1, 1, 0.5); // Make Bing logo semi transparent.
+            if (!BingTiledImageLayer.logoImage) {
+                BingTiledImageLayer.logoImage = new ScreenImage(WorldWind.configuration.bingLogoPlacement,
+                    WorldWind.configuration.baseUrl + "images/powered-by-bing.png");
+                BingTiledImageLayer.logoImage.imageColor = new Color(1, 1, 1, 0.5); // Make Bing logo semi transparent.
+            }
 
             if (BingTiledImageLayer.logoLastFrameTime !== dc.timestamp) {
                 BingTiledImageLayer.logoImage.screenOffset = WorldWind.configuration.bingLogoPlacement;

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -80,6 +80,9 @@ define([
 
             // Make Bing logo semi transparent.
             this.attribution.imageColor = new Color(1, 1, 1, 0.5);
+
+            // Make logo a static member so a single instance is shared between all subclasses.
+            BingTiledImageLayer.bingLogo = this.attribution;
         };
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
@@ -87,9 +90,9 @@ define([
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
             if (this.inCurrentFrame) {
-                this.attribution.screenOffset = this.logoPlacement;
-                this.attribution.imageOffset = this.logoAlignment;
-                this.attribution.render(dc);
+                BingTiledImageLayer.bingLogo.screenOffset = this.logoPlacement;
+                BingTiledImageLayer.bingLogo.imageOffset = this.logoAlignment;
+                BingTiledImageLayer.bingLogo.render(dc);
             }
         };
 

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -84,17 +84,17 @@ define([
 
         // Store last time the logo was rendered as a static member as a way to prevent subclasses from drawing
         // more than one logo at a time.
-        BingTiledImageLayer.lastTimeLogoWasRendered = 0;
+        BingTiledImageLayer.logoLastFrameTime = 0;
 
         BingTiledImageLayer.prototype = Object.create(MercatorTiledImageLayer.prototype);
 
         BingTiledImageLayer.prototype.doRender = function (dc) {
             MercatorTiledImageLayer.prototype.doRender.call(this, dc);
-            if (this.inCurrentFrame && BingTiledImageLayer.lastTimeLogoWasRendered !== dc.timestamp) {
+            if (this.inCurrentFrame && BingTiledImageLayer.logoLastFrameTime !== dc.timestamp) {
                 this.attribution.screenOffset = this.logoPlacement;
                 this.attribution.imageOffset = this.logoAlignment;
                 this.attribution.render(dc);
-                BingTiledImageLayer.lastTimeLogoWasRendered = this.attribution.lastFrameTime;
+                BingTiledImageLayer.logoLastFrameTime = this.attribution.lastFrameTime;
             }
         };
 


### PR DESCRIPTION
### Description of the Change
Previous modification to BingTiledImageLayer added a Bing logo ScreenImage to it in order to provide imagery attributions (#661). Inadvertently, this caused every subclass of BingTiledImageLayer to draw its own Bing logo when enabled, which resulted in multiple unnecessary logos being drawn in top of another.

This change makes the `ScreenImage` object that produces the logo a static member of `BingTiledImageLayer`, so this object is shared among all subclasses of it, correcting the previous implementation which produced a copy of the logo for each subclass, hence producing the logo repetition.

In order to understand private and static members in JavaScript, I looked here:
https://crockford.com/javascript/private.html
https://www.quora.com/How-do-you-create-static-variables-in-JavaScript

### Benefits
Solves the aforementioned bug and keeps current architecture, unlike my first proposal (#689).

### Potential Drawbacks
- Not a pattern that I've seen elsewhere in Web WorldWind. 
- Pointing the `ScreenImage` to `this` may be unnecessary.

### Applicable Issues
Closes #687.