### PR TITLE
New overlay layout as preparation for screen credits rearrangement

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -949,7 +949,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
          *     <li><code>baseUrl</code>: The URL of the directory containing the WorldWind Library and its resources.</li>
          *     <li><code>layerRetrievalQueueSize</code>: The number of concurrent tile requests allowed per layer. The default is 16.</li>
          *     <li><code>coverageRetrievalQueueSize</code>: The number of concurrent tile requests allowed per elevation coverage. The default is 16.</li>
-         *     <li><code>bingLogoPlacement</code>: An {@link Offset} to place a Bing logo attribution. The default is a 5px margin inset from the lower right corner of the screen.</li>
+         *     <li><code>bingLogoPlacement</code>: An {@link Offset} to place a Bing logo attribution. The default is a 7px margin inset from the lower right corner of the screen.</li>
          *     <li><code>bingLogoAlignment</code>: An {@link Offset} to align the Bing logo relative to its placement position. The default is the lower right corner of the logo.</li>
          * </ul>
          * @type {{gpuCacheSize: number}}

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -949,7 +949,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
          *     <li><code>baseUrl</code>: The URL of the directory containing the WorldWind Library and its resources.</li>
          *     <li><code>layerRetrievalQueueSize</code>: The number of concurrent tile requests allowed per layer. The default is 16.</li>
          *     <li><code>coverageRetrievalQueueSize</code>: The number of concurrent tile requests allowed per elevation coverage. The default is 16.</li>
-         *     <li><code>bingLogoPlacement</code>: An {@link Offset} to place a Bing logo attribution. The default is a 7px margin inset from the lower right corner of the screen.</li>
+         *     <li><code>bingLogoPlacement</code>: An {@link Offset} to place a Bing logo attribution. The default is a 5px margin inset from the lower right corner of the screen.</li>
          *     <li><code>bingLogoAlignment</code>: An {@link Offset} to align the Bing logo relative to its placement position. The default is the lower right corner of the logo.</li>
          * </ul>
          * @type {{gpuCacheSize: number}}

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -959,7 +959,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
             baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../'),
             layerRetrievalQueueSize: 16,
             coverageRetrievalQueueSize: 16,
-            bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 7, WorldWind.OFFSET_PIXELS, 7),
+            bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5),
             bingLogoAlignment: new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0)
         };
 

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -959,7 +959,7 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
             baseUrl: (WWUtil.worldwindlibLocation()) || (WWUtil.currentUrlSansFilePart() + '/../'),
             layerRetrievalQueueSize: 16,
             coverageRetrievalQueueSize: 16,
-            bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 5, WorldWind.OFFSET_PIXELS, 5),
+            bingLogoPlacement: new Offset(WorldWind.OFFSET_INSET_PIXELS, 7, WorldWind.OFFSET_PIXELS, 7),
             bingLogoAlignment: new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0)
         };
 

--- a/src/layer/CoordinatesDisplayLayer.js
+++ b/src/layer/CoordinatesDisplayLayer.js
@@ -148,7 +148,7 @@ define([
 
             if (canvasWidth > 650) { // large canvas, align the text with bottom center
                 x = (canvasWidth / 2) - 50;
-                y = 10;
+                y = 9;
                 yUnitsScreen = WorldWind.OFFSET_PIXELS;
                 yUnitsText = 0;
             } else if (canvasWidth > 400) { // medium canvas, align the text in the top left

--- a/src/layer/CoordinatesDisplayLayer.js
+++ b/src/layer/CoordinatesDisplayLayer.js
@@ -148,7 +148,7 @@ define([
 
             if (canvasWidth > 650) { // large canvas, align the text with bottom center
                 x = (canvasWidth / 2) - 50;
-                y = 5;
+                y = 10;
                 yUnitsScreen = WorldWind.OFFSET_PIXELS;
                 yUnitsText = 0;
             } else if (canvasWidth > 400) { // medium canvas, align the text in the top left

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -106,7 +106,7 @@ define([
             /**
              * An {@link Offset} indicating where to place the controls on the screen.
              * @type {Offset}
-             * @default The lower left corner of the window with a 10px margin.
+             * @default The lower left corner of the window with a 9px margin.
              */
             this.placement = new Offset(WorldWind.OFFSET_PIXELS, 9, WorldWind.OFFSET_PIXELS, 9);
 

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -108,7 +108,7 @@ define([
              * @type {Offset}
              * @default The lower left corner of the window.
              */
-            this.placement = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_FRACTION, 0);
+            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 10, WorldWind.OFFSET_PIXELS, 10);
 
             /**
              * An {@link Offset} indicating the alignment of the control collection relative to the

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -106,7 +106,7 @@ define([
             /**
              * An {@link Offset} indicating where to place the controls on the screen.
              * @type {Offset}
-             * @default The lower left corner of the window.
+             * @default The lower left corner of the window with a 10px margin.
              */
             this.placement = new Offset(WorldWind.OFFSET_PIXELS, 10, WorldWind.OFFSET_PIXELS, 10);
 

--- a/src/layer/ViewControlsLayer.js
+++ b/src/layer/ViewControlsLayer.js
@@ -108,7 +108,7 @@ define([
              * @type {Offset}
              * @default The lower left corner of the window with a 10px margin.
              */
-            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 10, WorldWind.OFFSET_PIXELS, 10);
+            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 9, WorldWind.OFFSET_PIXELS, 9);
 
             /**
              * An {@link Offset} indicating the alignment of the control collection relative to the


### PR DESCRIPTION
### Description of the Change
Made a slight adjustment to the positioning of ViewControlsLayer and CoordinatesDisplayLayer in such a way that a centered line of screen credits can be displayed below them, while attempting to maintain a pleasing look of the overlays whenever there are no credits.

### Why Should This Be In Core?
Makes way to add a new screen credits layout without the need to dynamically reposition the overlays, considering a screen credit font size of 10 with a bottom margin of 6px.

Here are some screenshots taken with the proposed overlay layout, and it can be seen live in the branch `test/quick_and_dirty_screen_credits`. BasicExample has the Digital Globe credits tacked on to the BMNGLandSatLayer so all our current credits can be seen at once.

This is how it looks in a canvas in landscape mode (and coordinates at the bottom):
![screenshot 2018-05-18 13 44 52](https://user-images.githubusercontent.com/7622894/40253903-1f66020a-5aa7-11e8-8cc3-b7c5b774317d.png)

And this is the same view without credits:
![screenshot 2018-05-18 13 44 53](https://user-images.githubusercontent.com/7622894/40254684-01b4d972-5aaa-11e8-8a79-83211060c6d5.png)

This is how it looks in portrait mode (iPhone 6 screen size):
![screenshot 2018-05-18 13 44 17](https://user-images.githubusercontent.com/7622894/40253983-760fd914-5aa7-11e8-8d6a-920a6158dd81.png)

And the same view, sans credits:
![screenshot 2018-05-18 13 44 18](https://user-images.githubusercontent.com/7622894/40254754-3fba2b8c-5aaa-11e8-8280-17137a51fc0b.png)

### Benefits
- No need to dynamically reposition the overlay depending on the presence of screen credits.
- The Bing logo didn't need to be repositioned, and it looks better aligned with this layout.

### Potential Drawbacks
- It comes down to aesthetics. The increased overlay margin may be seen as excessive in a mobile device if there are no screen credits. This proposal attempts to minimize this while maintaining an uncluttered view for the credits.

### Applicable Issues
Related to #489 and #645