### PR TITLE
New layout for screen credits

### DIFF
--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -44,17 +44,25 @@ define([
         var ScreenCreditController = function () {
             Layer.call(this, "ScreenCreditController");
 
+            /**
+             * An {@link Offset} indicating where to place the attributions on the screen.
+             * @type {Offset}
+             * @default The lower left corner of the window with an 11px left margin and a 2px bottom margin.
+             */
+            this.creditPlacement = new Offset(WorldWind.OFFSET_PIXELS, 11, WorldWind.OFFSET_PIXELS, 2);
+
+            /**
+             * The amount of horizontal spacing between adjacent attributions.
+             * @type {number}
+             * @default An 11px margin between attributions.
+             */
+            this.creditMargin = 11;
+
             // Apply 50% opacity to all shapes rendered by this layer.
             this.opacity = 0.5;
 
             // Internal. Intentionally not documented.
             this.credits = [];
-
-            // Internal. Intentionally not documented.
-            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 11, WorldWind.OFFSET_PIXELS, 2);
-
-            // Internal. Intentionally not documented.
-            this.creditMargin = 11;
         };
 
         ScreenCreditController.prototype = Object.create(Layer.prototype);
@@ -108,7 +116,7 @@ define([
 
         // Internal use only. Intentionally not documented.
         ScreenCreditController.prototype.doRender = function (dc) {
-            var point = this.placement.offsetForSize(dc.viewport.width, dc.viewport.height);
+            var point = this.creditPlacement.offsetForSize(dc.viewport.width, dc.viewport.height);
 
             for (var i = 0, len = this.credits.length; i < len; i++) {
                 // Place the credit text on screen and render it.

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -111,17 +111,16 @@ define([
 
         // Internal use only. Intentionally not documented.
         ScreenCreditController.prototype.doRender = function (dc) {
-            var textMetrics = {},
+            var creditWidth = 0,
                 i,
                 len;
 
-            textMetrics.width = 0;
             for (i = 0, len = this.credits.length; i < len; i++) {
-                this.credits[i].screenOffset.x += (textMetrics.width) * i;
+                this.credits[i].screenOffset.x += (creditWidth) * i;
                 if (i < len - 1) {
                     this.credits[i].text += ", ";
                 }
-                textMetrics = dc.ctx2D.measureText(this.credits[i].text);
+                creditWidth = dc.ctx2D.measureText(this.credits[i].text).width;
                 this.credits[i].render(dc);
             }
         };

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -119,6 +119,8 @@ define([
                 this.credits[i].screenOffset.x += (creditWidth) * i;
                 if (i < len - 1) {
                     this.credits[i].text += ", ";
+                } else {
+                    this.credits[i].text += ".";
                 }
                 creditWidth = dc.ctx2D.measureText(this.credits[i].text).width;
                 this.credits[i].render(dc);

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -44,18 +44,17 @@ define([
         var ScreenCreditController = function () {
             Layer.call(this, "ScreenCreditController");
 
+            // Apply 50% opacity to all shapes rendered by this layer.
+            this.opacity = 0.5;
+
             // Internal. Intentionally not documented.
             this.credits = [];
 
             // Internal. Intentionally not documented.
-            this.margin = 5;
+            this.placement = new Offset(WorldWind.OFFSET_PIXELS, 11, WorldWind.OFFSET_PIXELS, 2);
 
             // Internal. Intentionally not documented.
-            this.creditSpacing = 21;
-
-            // Internal. Intentionally not documented.
-            this.opacity = 0.5;
-
+            this.creditMargin = 11;
         };
 
         ScreenCreditController.prototype = Object.create(Layer.prototype);
@@ -92,9 +91,7 @@ define([
                 }
             }
 
-            var screenOffset = new Offset(WorldWind.OFFSET_PIXELS, 11, WorldWind.OFFSET_PIXELS, 2);
-
-            var credit = new ScreenText(screenOffset, creditString);
+            var credit = new ScreenText(new Offset(WorldWind.OFFSET_PIXELS, 0, WorldWind.OFFSET_PIXELS, 0), creditString);
             credit.attributes.font = new Font(10);
             credit.attributes.color = color;
             credit.attributes.enableOutline = false;
@@ -111,19 +108,20 @@ define([
 
         // Internal use only. Intentionally not documented.
         ScreenCreditController.prototype.doRender = function (dc) {
-            var creditWidth = 0,
-                i,
-                len;
+            var point = this.placement.offsetForSize(dc.viewport.width, dc.viewport.height);
 
-            for (i = 0, len = this.credits.length; i < len; i++) {
-                this.credits[i].screenOffset.x += (creditWidth) * i;
-                if (i < len - 1) {
-                    this.credits[i].text += ", ";
-                } else {
-                    this.credits[i].text += ".";
-                }
-                creditWidth = dc.ctx2D.measureText(this.credits[i].text).width;
+            for (var i = 0, len = this.credits.length; i < len; i++) {
+                // Place the credit text on screen and render it.
+                this.credits[i].screenOffset.x = point[0];
+                this.credits[i].screenOffset.y = point[1];
                 this.credits[i].render(dc);
+
+                // Advance the screen position for the next credit.
+                dc.textRenderer.typeFace = this.credits[i].attributes.font;
+                dc.textRenderer.outlineWidth = this.credits[i].attributes.outlineWidth;
+                dc.textRenderer.enableOutline = this.credits[i].attributes.enableOutline;
+                point[0] += dc.textRenderer.textSize(this.credits[i].text)[0];
+                point[0] += this.creditMargin;
             }
         };
 

--- a/src/render/ScreenCreditController.js
+++ b/src/render/ScreenCreditController.js
@@ -92,12 +92,13 @@ define([
                 }
             }
 
-            var screenOffset = new Offset(WorldWind.OFFSET_PIXELS, 0, WorldWind.OFFSET_PIXELS, 0);
+            var screenOffset = new Offset(WorldWind.OFFSET_PIXELS, 11, WorldWind.OFFSET_PIXELS, 2);
 
             var credit = new ScreenText(screenOffset, creditString);
+            credit.attributes.font = new Font(10);
             credit.attributes.color = color;
             credit.attributes.enableOutline = false;
-            credit.attributes.offset = new Offset(WorldWind.OFFSET_FRACTION, 1, WorldWind.OFFSET_FRACTION, 0.5);
+            credit.attributes.offset = new Offset(WorldWind.OFFSET_FRACTION, 0, WorldWind.OFFSET_FRACTION, 0);
 
             // Append new user property to store URL for hyperlinking.
             // (See BasicWorldWindowController.handleClickOrTap).
@@ -110,15 +111,18 @@ define([
 
         // Internal use only. Intentionally not documented.
         ScreenCreditController.prototype.doRender = function (dc) {
-            var creditOrdinal = 1,
+            var textMetrics = {},
                 i,
                 len;
 
+            textMetrics.width = 0;
             for (i = 0, len = this.credits.length; i < len; i++) {
-                this.credits[i].screenOffset.x = dc.viewport.width - (this.margin);
-                this.credits[i].screenOffset.y = creditOrdinal * this.creditSpacing;
+                this.credits[i].screenOffset.x += (textMetrics.width) * i;
+                if (i < len - 1) {
+                    this.credits[i].text += ", ";
+                }
+                textMetrics = dc.ctx2D.measureText(this.credits[i].text);
                 this.credits[i].render(dc);
-                creditOrdinal++;
             }
         };
 


### PR DESCRIPTION
### Description of the Change
Changed size and layout for screen credits. This change positions every attribution beneath the View Controls, aligning them to the left side of the canvas, appending a comma at the end of each attribution to enlist them horizontally (a period in the case of the last one):
![screenshot 2018-05-21 13 12 04](https://user-images.githubusercontent.com/7622894/40322702-d9f89ac6-5cf8-11e8-9c36-0ee1b1adea4a.png)

This proposal was tested with multiple attributions (more than currently available credits for OpenStreetMap and DigitalGlobe) while ensuring that current hyperlinking capabilities are retained.

### Why Should This Be In Core?
This new layout aids in minimizing cluttering due to screen credits, both by repositioning them in a less obtrusive place while reducing the screen real estate they occupy by constricting them to a single line in a smaller font than before.

### Benefits
- Works well regardless of screen size or layout mode (portrait or landscape).
- Reduces screen real estate of screen credits compared to previous layout.
- Simple way of reducing cluttering induced by screen credits without increasing complexity to the ScreenCreditController.
- Complements previous work on separating the Bing Logo from text-based screen credits.

### Potential Drawbacks
- Smaller font size may make the attributions less easy on the eyes.
- Lack of contrast depending on globe imagery is not addressed.
- Does not truncate the overall width of all screen credits according to screen width.

### Applicable Issues
Relates to #489 and #492.