### PR TITLE
Corrected logger level comment in examples

### DIFF
--- a/examples/Annotations.js
+++ b/examples/Annotations.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
               AnnotationController) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/BasicExample.js
+++ b/examples/BasicExample.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -23,7 +23,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
     function (WorldWind, LayerManager) {
     "use strict";
 
-    // Tell WorldWindow to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
     WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
     // Create the WorldWindow.

--- a/examples/Configuration.js
+++ b/examples/Configuration.js
@@ -23,7 +23,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Configure the amount of GPU memory to use.

--- a/examples/CustomPlacemark.js
+++ b/examples/CustomPlacemark.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/DeepPicking.js
+++ b/examples/DeepPicking.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/DigitalGlobe.js
+++ b/examples/DigitalGlobe.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GeoJSON.js
+++ b/examples/GeoJSON.js
@@ -20,7 +20,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GeoJSONExporter.js
+++ b/examples/GeoJSONExporter.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GeoTiffExample.js
+++ b/examples/GeoTiffExample.js
@@ -20,7 +20,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWindow to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GeographicMeshes.js
+++ b/examples/GeographicMeshes.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GeographicText.js
+++ b/examples/GeographicText.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/GoToLocation.js
+++ b/examples/GoToLocation.js
@@ -23,7 +23,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/KmlExample.js
+++ b/examples/KmlExample.js
@@ -18,7 +18,7 @@ requirejs(['./WorldWindShim',
     function (WorldWind,
               LayerManager) {
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/Measurements.js
+++ b/examples/Measurements.js
@@ -31,7 +31,7 @@ requirejs([
         var projectedAreaSpan = document.getElementById('projected-area');
         var terrainAreaSpan = document.getElementById('terrain-area');
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWinow.

--- a/examples/MultiWindow.js
+++ b/examples/MultiWindow.js
@@ -19,7 +19,7 @@
 requirejs(['./WorldWindShim'], function () {
     "use strict";
 
-    // Tell WorldWind to log only warnings.
+    // Tell WorldWind to log only warnings and errors.
     WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
     // Make a layer that shows a Path and is shared among the WorldWindows.

--- a/examples/ParseUrlArguments.js
+++ b/examples/ParseUrlArguments.js
@@ -45,7 +45,7 @@ requirejs(['./WorldWindShim',
 
         var args = parseArgs();
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/PickAllShapesInRegion.js
+++ b/examples/PickAllShapesInRegion.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/PlacemarksAndPicking.js
+++ b/examples/PlacemarksAndPicking.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/RefreshImagery.js
+++ b/examples/RefreshImagery.js
@@ -23,7 +23,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/Shapefiles.js
+++ b/examples/Shapefiles.js
@@ -19,7 +19,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -41,7 +41,7 @@ imagery, the Landsat imagery and the DTED0 elevations in its Earth directory.
     // Define the event listener to initialize Web WorldWind.
     function eventWindowLoaded() {
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create a WorldWindow for the canvas.

--- a/examples/StarField.js
+++ b/examples/StarField.js
@@ -22,7 +22,7 @@ requirejs([
               LayerManager) {
         'use strict';
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/SunSimulation.js
+++ b/examples/SunSimulation.js
@@ -20,7 +20,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/SurfaceShapes.js
+++ b/examples/SurfaceShapes.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/TestMovingSurfaceShapes.js
+++ b/examples/TestMovingSurfaceShapes.js
@@ -24,7 +24,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/WMS.js
+++ b/examples/WMS.js
@@ -20,7 +20,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/WMTS.js
+++ b/examples/WMTS.js
@@ -22,7 +22,7 @@ requirejs([
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/Wkt.js
+++ b/examples/Wkt.js
@@ -20,7 +20,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.

--- a/examples/WktExporter.js
+++ b/examples/WktExporter.js
@@ -22,7 +22,7 @@ requirejs(['./WorldWindShim',
               LayerManager) {
         "use strict";
 
-        // Tell WorldWind to log only warnings.
+        // Tell WorldWind to log only warnings and errors.
         WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
         // Create the WorldWindow.


### PR DESCRIPTION
### Description of the Change
Every example sets the Logger to log warnings _and_ errors instead of "only warnings", but only a few examples referred to both. Plus in some examples, 'WorldWindow' was mistakenly referred to instead of 'WorldWind' in this particular comment.

 Now every example is documented accordingly.

### Applicable Issues
Relates to #539.