### PR TITLE
Add atmosphere layer to black background to all examples

### DIFF
--- a/.idea/runConfigurations/Atmosphere.xml
+++ b/.idea/runConfigurations/Atmosphere.xml
@@ -1,5 +1,0 @@
-<component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Atmosphere" type="JavascriptDebugType" factoryName="JavaScript Debug" uri="http://localhost:63342/WebWorldWind/examples/Atmosphere.html">
-    <method />
-  </configuration>
-</component>

--- a/.idea/runConfigurations/SunSimulation.xml
+++ b/.idea/runConfigurations/SunSimulation.xml
@@ -1,0 +1,5 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="SunSimulation" type="JavascriptDebugType" factoryName="JavaScript Debug" uri="http://localhost:63342/WebWorldWind/examples/SunSimulation.html">
+    <method />
+  </configuration>
+</component>

--- a/examples/Annotations.html
+++ b/examples/Annotations.html
@@ -65,7 +65,8 @@
 
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Annotations.js
+++ b/examples/Annotations.js
@@ -30,6 +30,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Annotations.js
+++ b/examples/Annotations.js
@@ -30,6 +30,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/BasicExample.html
+++ b/examples/BasicExample.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/BasicExample.js
+++ b/examples/BasicExample.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
             {layer: new WorldWind.OpenStreetMapImageLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/BasicExample.js
+++ b/examples/BasicExample.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
             {layer: new WorldWind.OpenStreetMapImageLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/BlueMarbleTimeSeries.html
+++ b/examples/BlueMarbleTimeSeries.html
@@ -26,7 +26,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -43,7 +43,7 @@ requirejs(['./WorldWindShim',
         // which is initiated below.
         wwd.addLayer(blueMarbleTimeSeries);
 
-        // Add Atmosphere layer.
+        // Add atmosphere layer on top of base imagery layer.
         wwd.addLayer(new WorldWind.AtmosphereLayer());
         // Add WorldWind UI layers.
         wwd.addLayer(new WorldWind.CompassLayer());

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -43,6 +43,8 @@ requirejs(['./WorldWindShim',
         // which is initiated below.
         wwd.addLayer(blueMarbleTimeSeries);
 
+        // Add Atmosphere layer.
+        wwd.addLayer(new WorldWind.AtmosphereLayer());
         // Add WorldWind UI layers.
         wwd.addLayer(new WorldWind.CompassLayer());
         wwd.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd));

--- a/examples/Collada.html
+++ b/examples/Collada.html
@@ -30,7 +30,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
         {layer: new WorldWind.BingAerialLayer(null), enabled: false},
         {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
         {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+        // Add atmosphere layer on top of all base layers.
         {layer: new WorldWind.AtmosphereLayer(), enabled: true},
         // WorldWindow UI layers.
         {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
         {layer: new WorldWind.BingAerialLayer(null), enabled: false},
         {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
         {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+        {layer: new WorldWind.AtmosphereLayer(), enabled: true},
         // WorldWindow UI layers.
         {layer: new WorldWind.CompassLayer(), enabled: true},
         {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/Configuration.html
+++ b/examples/Configuration.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Configuration.js
+++ b/examples/Configuration.js
@@ -39,6 +39,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Configuration.js
+++ b/examples/Configuration.js
@@ -39,6 +39,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/CustomPlacemark.html
+++ b/examples/CustomPlacemark.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/CustomPlacemark.js
+++ b/examples/CustomPlacemark.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/CustomPlacemark.js
+++ b/examples/CustomPlacemark.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/DeepPicking.html
+++ b/examples/DeepPicking.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/DeepPicking.js
+++ b/examples/DeepPicking.js
@@ -103,6 +103,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/DeepPicking.js
+++ b/examples/DeepPicking.js
@@ -103,6 +103,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/DigitalGlobe.html
+++ b/examples/DigitalGlobe.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/DigitalGlobe.js
+++ b/examples/DigitalGlobe.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
                 enabled: true},
             {layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe with Roads", "digitalglobe.n6nhclo2", accessToken),
                 enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWind UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/DigitalGlobe.js
+++ b/examples/DigitalGlobe.js
@@ -32,14 +32,11 @@ requirejs(['./WorldWindShim',
         var layers = [
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
-            {
-                layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe", "digitalglobe.n6ngnadl", accessToken),
-                enabled: true
-            },
-            {
-                layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe with Roads", "digitalglobe.n6nhclo2", accessToken),
-                enabled: false
-            },
+            {layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe", "digitalglobe.n6ngnadl", accessToken),
+                enabled: true},
+            {layer: new WorldWind.DigitalGlobeTiledImageLayer("Digital Globe with Roads", "digitalglobe.n6nhclo2", accessToken),
+                enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWind UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeoJSON.html
+++ b/examples/GeoJSON.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GeoJSON.js
+++ b/examples/GeoJSON.js
@@ -30,6 +30,7 @@ requirejs(['./WorldWindShim',
         var layers = [
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
+            // Add atmosphere layer on top of base layer.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/GeoJSON.js
+++ b/examples/GeoJSON.js
@@ -28,8 +28,9 @@ requirejs(['./WorldWindShim',
 
         // Create and add layers to the WorldWindow.
         var layers = [
-            // Imagery layer.
+            // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeoJSONExporter.html
+++ b/examples/GeoJSONExporter.html
@@ -39,7 +39,8 @@
             <textarea id="geoJSONTxtArea" rows="7" cols="35"></textarea>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GeoJSONExporter.js
+++ b/examples/GeoJSONExporter.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeoJSONExporter.js
+++ b/examples/GeoJSONExporter.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/GeoTiffExample.html
+++ b/examples/GeoTiffExample.html
@@ -37,7 +37,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GeoTiffExample.js
+++ b/examples/GeoTiffExample.js
@@ -31,6 +31,7 @@ requirejs(['./WorldWindShim',
             //Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeoTiffExample.js
+++ b/examples/GeoTiffExample.js
@@ -31,6 +31,7 @@ requirejs(['./WorldWindShim',
             //Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/GeographicMeshes.html
+++ b/examples/GeographicMeshes.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GeographicMeshes.js
+++ b/examples/GeographicMeshes.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeographicMeshes.js
+++ b/examples/GeographicMeshes.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/GeographicText.html
+++ b/examples/GeographicText.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GeographicText.js
+++ b/examples/GeographicText.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GeographicText.js
+++ b/examples/GeographicText.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/GoToLocation.html
+++ b/examples/GoToLocation.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/GoToLocation.js
+++ b/examples/GoToLocation.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/GoToLocation.js
+++ b/examples/GoToLocation.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/KmlExample.html
+++ b/examples/KmlExample.html
@@ -45,7 +45,8 @@
             <div id="treeControls" style="height: 600px; overflow-y: auto; overflow-x: hidden;"></div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/KmlExample.js
+++ b/examples/KmlExample.js
@@ -29,6 +29,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/KmlExample.js
+++ b/examples/KmlExample.js
@@ -29,6 +29,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Measurements.html
+++ b/examples/Measurements.html
@@ -43,7 +43,8 @@
             <p>Terrain area: <span id="terrain-area">0</span> km2</p>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Measurements.js
+++ b/examples/Measurements.js
@@ -40,12 +40,14 @@ requirejs([
         // Create and add layers to the WorldWindow.
         // Imagery layers.
         var BNMGLayer = new WorldWind.BMNGLayer();
+        var AtmosphereLayer = new WorldWind.AtmosphereLayer();
         var pathLayer = new WorldWind.RenderableLayer('Path');
         // WorldWindow UI layer.
         var CoordinatesDisplayLayer = new WorldWind.CoordinatesDisplayLayer(wwd);
         wwd.addLayer(BNMGLayer);
-        wwd.addLayer(CoordinatesDisplayLayer);
+        wwd.addLayer(AtmosphereLayer);
         wwd.addLayer(pathLayer);
+        wwd.addLayer(CoordinatesDisplayLayer);
 
         var pathPositions = [
             new WorldWind.Position(41.8267, -98.7686, 0),

--- a/examples/Measurements.js
+++ b/examples/Measurements.js
@@ -45,6 +45,7 @@ requirejs([
         // WorldWindow UI layer.
         var CoordinatesDisplayLayer = new WorldWind.CoordinatesDisplayLayer(wwd);
         wwd.addLayer(BNMGLayer);
+        // Add atmosphere layer on top of base imagery layer.
         wwd.addLayer(AtmosphereLayer);
         wwd.addLayer(pathLayer);
         wwd.addLayer(CoordinatesDisplayLayer);

--- a/examples/MultiWindow.html
+++ b/examples/MultiWindow.html
@@ -10,16 +10,16 @@
 <body>
 <div id="page">
     <div id="div1" style="position:absolute; top:20px; left:20px;">
-        <canvas id="canvasOne" width="300" height="300" style="border: 10px solid mediumblue;">
+        <canvas id="canvasOne" width="300" height="300" style="border: 10px solid mediumblue; background-color: black;">
             Your browser does not support HTML5 Canvas.
         </canvas>
     </div>
     <div id="div2" style="position:absolute; top:20px; left:350px;" >
-        <canvas id="canvasTwo" width="300" height="300" style="border: 10px solid #ff0000;">
+        <canvas id="canvasTwo" width="300" height="300" style="border: 10px solid #ff0000; background-color: black;">
         </canvas>
     </div>
     <div id="div3" style="position:absolute; top:20px; left:680px;" >
-        <canvas id="canvasThree" width="300" height="300" style="border: 10px solid #00ff00;">
+        <canvas id="canvasThree" width="300" height="300" style="border: 10px solid #00ff00; background-color: black;">
         </canvas>
     </div>
 </div>

--- a/examples/MultiWindow.js
+++ b/examples/MultiWindow.js
@@ -46,10 +46,12 @@ requirejs(['./WorldWindShim'], function () {
 
     // Create the shared shape layer and imagery layer
     var pathLayer = makePathLayer(),
-        imageryLayer = new WorldWind.BingAerialWithLabelsLayer(null);
+        imageryLayer = new WorldWind.BingAerialWithLabelsLayer(null),
+        atmosphereLayer = new WorldWind.AtmosphereLayer();
 
     var wwd1 = new WorldWind.WorldWindow("canvasOne");
     wwd1.addLayer(imageryLayer);
+    wwd1.addLayer(atmosphereLayer);
     wwd1.addLayer(pathLayer);
     // Add a compass layer, view controls layer, and coordinates display layer. Each WorldWindow must have its own.
     wwd1.addLayer(new WorldWind.CompassLayer());
@@ -58,6 +60,7 @@ requirejs(['./WorldWindShim'], function () {
 
     var wwd2 = new WorldWind.WorldWindow("canvasTwo");
     wwd2.addLayer(imageryLayer);
+    wwd2.addLayer(atmosphereLayer);
     wwd2.addLayer(pathLayer);
     wwd2.addLayer(new WorldWind.CompassLayer());
     wwd2.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd2));
@@ -65,6 +68,7 @@ requirejs(['./WorldWindShim'], function () {
 
     var wwd3 = new WorldWind.WorldWindow("canvasThree");
     wwd3.addLayer(imageryLayer);
+    wwd3.addLayer(atmosphereLayer);
     wwd3.addLayer(pathLayer);
     wwd3.addLayer(new WorldWind.CompassLayer());
     wwd3.addLayer(new WorldWind.CoordinatesDisplayLayer(wwd3));

--- a/examples/NDVIViewer.html
+++ b/examples/NDVIViewer.html
@@ -164,7 +164,8 @@
         </div>
 
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/NDVIViewer.js
+++ b/examples/NDVIViewer.js
@@ -28,8 +28,9 @@ requirejs([
 
         // Create and add layers to the WorldWindow.
         var layers = [
-            // Imagery layers.
+            // Imagery layer.
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of imagery layer.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/NDVIViewer.js
+++ b/examples/NDVIViewer.js
@@ -28,8 +28,9 @@ requirejs([
 
         // Create and add layers to the WorldWindow.
         var layers = [
-            // Imagery layer.
+            // Imagery layers.
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},
             {layer: new WorldWind.ViewControlsLayer(wwd), enabled: true}

--- a/examples/ParseUrlArguments.html
+++ b/examples/ParseUrlArguments.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/ParseUrlArguments.js
+++ b/examples/ParseUrlArguments.js
@@ -59,6 +59,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/ParseUrlArguments.js
+++ b/examples/ParseUrlArguments.js
@@ -59,6 +59,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Paths.html
+++ b/examples/Paths.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Paths.js
+++ b/examples/Paths.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/Paths.js
+++ b/examples/Paths.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/PickAllShapesInRegion.html
+++ b/examples/PickAllShapesInRegion.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/PickAllShapesInRegion.js
+++ b/examples/PickAllShapesInRegion.js
@@ -31,6 +31,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/PickAllShapesInRegion.js
+++ b/examples/PickAllShapesInRegion.js
@@ -31,6 +31,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/PlacemarksAndPicking.html
+++ b/examples/PlacemarksAndPicking.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/PlacemarksAndPicking.js
+++ b/examples/PlacemarksAndPicking.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/PlacemarksAndPicking.js
+++ b/examples/PlacemarksAndPicking.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Polygons.html
+++ b/examples/Polygons.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Polygons.js
+++ b/examples/Polygons.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/Polygons.js
+++ b/examples/Polygons.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/RefreshImagery.html
+++ b/examples/RefreshImagery.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/RefreshImagery.js
+++ b/examples/RefreshImagery.js
@@ -33,8 +33,9 @@ requirejs(['./WorldWindShim',
 
         // Create and add layers to the WorldWindow, including our previously created layer to be refreshed.
         var layers = [
-            // Imagery layers.
+            // Imagery layer.
             {layer: layerToRefresh, enabled: true},
+            // Add atmosphere layer on top of imagery layer.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/RefreshImagery.js
+++ b/examples/RefreshImagery.js
@@ -33,8 +33,9 @@ requirejs(['./WorldWindShim',
 
         // Create and add layers to the WorldWindow, including our previously created layer to be refreshed.
         var layers = [
-            // Imagery layer.
+            // Imagery layers.
             {layer: layerToRefresh, enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/ScreenImage.html
+++ b/examples/ScreenImage.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/ScreenImage.js
+++ b/examples/ScreenImage.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/ScreenImage.js
+++ b/examples/ScreenImage.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/ScreenText.html
+++ b/examples/ScreenText.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -33,9 +33,9 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
+            {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
-            {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},
             {layer: new WorldWind.ViewControlsLayer(wwd), enabled: true}

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/ScreenText.js
+++ b/examples/ScreenText.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Shapefiles.html
+++ b/examples/Shapefiles.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Shapefiles.js
+++ b/examples/Shapefiles.js
@@ -30,6 +30,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Shapefiles.js
+++ b/examples/Shapefiles.js
@@ -30,6 +30,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/SunSimulation.html
+++ b/examples/SunSimulation.html
@@ -7,13 +7,14 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-    <script data-main="Atmosphere" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
+    <script data-main="SunSimulation"
+            src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 
 </head>
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">WorldWind Atmosphere</h1>
+        <h1 style="text-align:center">WorldWind Sun Simulation</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">
@@ -23,11 +24,6 @@
             <br>
             <h4>Layers</h4>
             <div class="list-group" id="layerList">
-            </div>
-            <br>
-            <div>
-                <label for="sun-simulation">Simulate Sun</label>
-                <input id="sun-simulation" type="checkbox" />
             </div>
             <br>
             <h4>Destination</h4>

--- a/examples/SunSimulation.js
+++ b/examples/SunSimulation.js
@@ -41,35 +41,23 @@ requirejs(['./WorldWindShim',
             wwd.addLayer(layers[l].layer);
         }
 
+        // The Sun simulation is a feature of Atmosphere layer. We'll create and add the layer.
         var atmosphereLayer = new WorldWind.AtmosphereLayer();
         wwd.addLayer(atmosphereLayer);
 
+        // Atmosphere layer requires a date to simulate the Sun position at that time.
+        // In this case the current date will be given to initialize the simulation.
+        var timeStamp = Date.now();
+
+        // Update the Sun position in 3 minute steps, every 64 ms in real time. Then redraw the scene.
+        setInterval(function () {
+            timeStamp += 180 * 1000;
+            atmosphereLayer.time = new Date(timeStamp);
+            wwd.redraw();
+        }, 64);
+
         // Create a layer manager for controlling layer visibility.
         var layerManager = new LayerManager(wwd);
-
-        var sunSimulationCheckBox = document.getElementById('sun-simulation');
-        var sunInterval = 0;
-        var timeStamp = Date.now();
-        sunSimulationCheckBox.addEventListener('change', onSunCheckBoxClick, false);
-
-        function onSunCheckBoxClick() {
-            if (this.checked) {
-                runSunSimulation();
-            }
-            else {
-                atmosphereLayer.time = null;
-                clearInterval(sunInterval);
-                wwd.redraw();
-            }
-        }
-
-        function runSunSimulation() {
-            sunInterval = setInterval(function () {
-                timeStamp += 180 * 1000;
-                atmosphereLayer.time = new Date(timeStamp);
-                wwd.redraw();
-            }, 64);
-        }
 
     });
 

--- a/examples/SurfaceImage.html
+++ b/examples/SurfaceImage.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/SurfaceImage.js
+++ b/examples/SurfaceImage.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/SurfaceImage.js
+++ b/examples/SurfaceImage.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/SurfaceShapes.html
+++ b/examples/SurfaceShapes.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/SurfaceShapes.js
+++ b/examples/SurfaceShapes.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/SurfaceShapes.js
+++ b/examples/SurfaceShapes.js
@@ -33,6 +33,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/TestMovingSurfaceShapes.html
+++ b/examples/TestMovingSurfaceShapes.html
@@ -36,7 +36,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/TestMovingSurfaceShapes.js
+++ b/examples/TestMovingSurfaceShapes.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGOneImageLayer(), enabled: true},
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.ShowTessellationLayer(), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/TestMovingSurfaceShapes.js
+++ b/examples/TestMovingSurfaceShapes.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BMNGOneImageLayer(), enabled: true},
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.ShowTessellationLayer(), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/TriangleMeshes.html
+++ b/examples/TriangleMeshes.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/TriangleMeshes.js
+++ b/examples/TriangleMeshes.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/TriangleMeshes.js
+++ b/examples/TriangleMeshes.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/WMS.html
+++ b/examples/WMS.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/WMS.js
+++ b/examples/WMS.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/WMS.js
+++ b/examples/WMS.js
@@ -34,6 +34,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/WMTS.html
+++ b/examples/WMTS.html
@@ -35,7 +35,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/WMTS.js
+++ b/examples/WMTS.js
@@ -36,6 +36,7 @@ requirejs([
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/WMTS.js
+++ b/examples/WMTS.js
@@ -36,6 +36,7 @@ requirejs([
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Wkt.html
+++ b/examples/Wkt.html
@@ -41,7 +41,8 @@
             </div>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/Wkt.js
+++ b/examples/Wkt.js
@@ -28,8 +28,9 @@ requirejs(['./WorldWindShim',
 
         // Create and add layers to the WorldWindow.
         var layers = [
-            // Imagery layers.
+            // Imagery layer.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
+            // Add atmosphere layer on top of base layer.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},

--- a/examples/Wkt.js
+++ b/examples/Wkt.js
@@ -28,8 +28,9 @@ requirejs(['./WorldWindShim',
 
         // Create and add layers to the WorldWindow.
         var layers = [
-            // Imagery layer.
+            // Imagery layers.
             {layer: new WorldWind.BMNGLayer(), enabled: true},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/WktExporter.html
+++ b/examples/WktExporter.html
@@ -39,7 +39,8 @@
             <textarea id="wktTxtArea" rows="7" cols="35"></textarea>
         </div>
         <div class="col-sm-9" id="globe">
-            <canvas id="canvasOne" width="1000" height="1000" style="width: 100%; height: auto">
+            <canvas id="canvasOne" width="1000" height="1000"
+                    style="width: 100%; height: auto; background-color: black;">
                 Your browser does not support HTML5 Canvas.
             </canvas>
         </div>

--- a/examples/WktExporter.js
+++ b/examples/WktExporter.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},
             {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},

--- a/examples/WktExporter.js
+++ b/examples/WktExporter.js
@@ -36,6 +36,7 @@ requirejs(['./WorldWindShim',
             {layer: new WorldWind.BingAerialLayer(null), enabled: false},
             {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: true},
             {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
             {layer: new WorldWind.AtmosphereLayer(), enabled: true},
             // WorldWindow UI layers.
             {layer: new WorldWind.CompassLayer(), enabled: true},


### PR DESCRIPTION
### Description of the Change

Last step in changing Atmosphere Layer to a Sun Simulation Example. Added the atmosphere layer with a black css-styled background. 

### Why Should This Be In Core?

### Benefits

### Potential Drawbacks

### Applicable Issues