### PR TITLE
Corrected examples names in their HTML documents

### DIFF
--- a/examples/BlueMarbleTimeSeries.html
+++ b/examples/BlueMarbleTimeSeries.html
@@ -13,7 +13,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">Blue Marble Time Series</h1>
+        <h1 style="text-align:center"> WorldWind Blue Marble Time Series</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/DigitalGlobe.html
+++ b/examples/DigitalGlobe.html
@@ -12,7 +12,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">Digital Globe Imagery</h1>
+        <h1 style="text-align:center">WorldWind Digital Globe Imagery</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/GeoJSONExporter.html
+++ b/examples/GeoJSONExporter.html
@@ -12,7 +12,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">World Wind GeoJSON Exporter</h1>
+        <h1 style="text-align:center">WorldWind GeoJSON Exporter</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/ParseUrlArguments.html
+++ b/examples/ParseUrlArguments.html
@@ -12,7 +12,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">Argument Parsing</h1>
+        <h1 style="text-align:center">WorldWind URL Argument Parsing</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/SimplestExample.html
+++ b/examples/SimplestExample.html
@@ -3,7 +3,7 @@
 <html>
 <head lang="en">
     <meta charset="UTF-8">
-    <title>WorldWind Example</title>
+    <title>WorldWind Simplest Example</title>
     <!-- Include the Web WorldWind library. -->
     <script src="../worldwind.min.js" type="text/javascript"></script>
 </head>

--- a/examples/Standalone.html
+++ b/examples/Standalone.html
@@ -23,7 +23,7 @@ imagery, the Landsat imagery and the DTED0 elevations in its Earth directory.
 <html>
 <head lang="en">
     <meta charset="UTF-8">
-    <title>WorldWind Example</title>
+    <title>WorldWind Standalone Example</title>
     <!-- Include the Web WorldWind library. -->
     <script src="../worldwind.min.js" type="text/javascript"></script>
 </head>

--- a/examples/TestMovingSurfaceShapes.html
+++ b/examples/TestMovingSurfaceShapes.html
@@ -13,7 +13,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">Moving SurfaceShapes Test</h1>
+        <h1 style="text-align:center">WorldWind Moving SurfaceShapes Test</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/WKT.html
+++ b/examples/WKT.html
@@ -13,7 +13,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">World Wind WKT</h1>
+        <h1 style="text-align:center">WorldWind Well Known Text Example</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">

--- a/examples/WktExporter.html
+++ b/examples/WktExporter.html
@@ -12,7 +12,7 @@
 <body>
 <div class="container">
     <div class="jumbotron hidden-xs">
-        <h1 style="text-align:center">World Wind WKT Exporter</h1>
+        <h1 style="text-align:center">WorldWind WKT Exporter</h1>
     </div>
     <div class="row">
         <div class="col-sm-3">


### PR DESCRIPTION
### Description of the Change
Most examples display in their HTML doc the following title: "WorldWind [theme of the example] Example".

Some of them didn't, and a couple of them featured "World Wind" instead.

This PR addresses this.

### Applicable Issues
Relates to #539