### PR TITLE
Rollback screen credit hyperlink support

### DIFF
--- a/src/BasicWorldWindowController.js
+++ b/src/BasicWorldWindowController.js
@@ -104,12 +104,12 @@ define([
             this.rotationRecognizer.requireRecognizerToFail(this.tiltRecognizer);
 
             // Intentionally not documented.
-            this.tapRecognizer = new TapRecognizer(this.wwd, null);
-            this.tapRecognizer.addListener(this);
+            // this.tapRecognizer = new TapRecognizer(this.wwd, null);
+            // this.tapRecognizer.addListener(this);
 
             // Intentionally not documented.
-            this.clickRecognizer = new ClickRecognizer(this.wwd, null);
-            this.clickRecognizer.addListener(this);
+            // this.clickRecognizer = new ClickRecognizer(this.wwd, null);
+            // this.clickRecognizer.addListener(this);
 
             // Intentionally not documented.
             this.beginPoint = new Vec2(0, 0);
@@ -161,28 +161,28 @@ define([
             else if (recognizer === this.tiltRecognizer) {
                 this.handleTilt(recognizer);
             }
-            else if (recognizer === this.clickRecognizer || recognizer === this.tapRecognizer) {
-                this.handleClickOrTap(recognizer);
-            }
+            // else if (recognizer === this.clickRecognizer || recognizer === this.tapRecognizer) {
+            //     this.handleClickOrTap(recognizer);
+            // }
         };
 
         // Intentionally not documented.
-        BasicWorldWindowController.prototype.handleClickOrTap = function (recognizer) {
-            if (recognizer.state === WorldWind.RECOGNIZED) {
-                var pickPoint = this.wwd.canvasCoordinates(recognizer.clientX, recognizer.clientY);
-
-                // Identify if the top picked object contains a URL for hyperlinking
-                var pickList = this.wwd.pick(pickPoint);
-                var topObject = pickList.topPickedObject();
-                // If the url object was appended, open the hyperlink
-                if (topObject &&
-                    topObject.userObject &&
-                    topObject.userObject.userProperties &&
-                    topObject.userObject.userProperties.url) {
-                    window.open(topObject.userObject.userProperties.url, "_blank");
-                }
-            }
-        };
+        // BasicWorldWindowController.prototype.handleClickOrTap = function (recognizer) {
+        //     if (recognizer.state === WorldWind.RECOGNIZED) {
+        //         var pickPoint = this.wwd.canvasCoordinates(recognizer.clientX, recognizer.clientY);
+        //
+        //         // Identify if the top picked object contains a URL for hyperlinking
+        //         var pickList = this.wwd.pick(pickPoint);
+        //         var topObject = pickList.topPickedObject();
+        //         // If the url object was appended, open the hyperlink
+        //         if (topObject &&
+        //             topObject.userObject &&
+        //             topObject.userObject.userProperties &&
+        //             topObject.userObject.userProperties.url) {
+        //             window.open(topObject.userObject.userProperties.url, "_blank");
+        //         }
+        //     }
+        // };
 
         // Intentionally not documented.
         BasicWorldWindowController.prototype.handlePanOrDrag = function (recognizer) {

--- a/src/globe/Globe.js
+++ b/src/globe/Globe.js
@@ -362,6 +362,12 @@ define([
                     "missingResult"));
             }
 
+            // For backwards compatibility, check whether the projection defines a surfaceNormalAtLocation function
+            // before calling it. If it's not available, use the old code to compute the normal.
+            if (this.projection.surfaceNormalAtLocation) {
+                return this.projection.surfaceNormalAtLocation(this, latitude, longitude, result);
+            }
+
             if (this.is2D()) {
                 result[0] = 0;
                 result[1] = 0;
@@ -373,13 +379,11 @@ define([
             var cosLat = Math.cos(latitude * Angle.DEGREES_TO_RADIANS),
                 cosLon = Math.cos(longitude * Angle.DEGREES_TO_RADIANS),
                 sinLat = Math.sin(latitude * Angle.DEGREES_TO_RADIANS),
-                sinLon = Math.sin(longitude * Angle.DEGREES_TO_RADIANS),
-                eqSquared = this.equatorialRadius * this.equatorialRadius,
-                polSquared = this.polarRadius * this.polarRadius;
+                sinLon = Math.sin(longitude * Angle.DEGREES_TO_RADIANS);
 
-            result[0] = cosLat * sinLon / eqSquared;
-            result[1] = (1 - this.eccentricitySquared) * sinLat / polSquared;
-            result[2] = cosLat * cosLon / eqSquared;
+            result[0] = cosLat * sinLon;
+            result[1] = sinLat;
+            result[2] = cosLat * cosLon;
 
             return result.normalize();
         };

--- a/src/globe/Globe.js
+++ b/src/globe/Globe.js
@@ -362,12 +362,6 @@ define([
                     "missingResult"));
             }
 
-            // For backwards compatibility, check whether the projection defines a surfaceNormalAtLocation function
-            // before calling it. If it's not available, use the old code to compute the normal.
-            if (this.projection.surfaceNormalAtLocation) {
-                return this.projection.surfaceNormalAtLocation(this, latitude, longitude, result);
-            }
-
             if (this.is2D()) {
                 result[0] = 0;
                 result[1] = 0;
@@ -379,11 +373,13 @@ define([
             var cosLat = Math.cos(latitude * Angle.DEGREES_TO_RADIANS),
                 cosLon = Math.cos(longitude * Angle.DEGREES_TO_RADIANS),
                 sinLat = Math.sin(latitude * Angle.DEGREES_TO_RADIANS),
-                sinLon = Math.sin(longitude * Angle.DEGREES_TO_RADIANS);
+                sinLon = Math.sin(longitude * Angle.DEGREES_TO_RADIANS),
+                eqSquared = this.equatorialRadius * this.equatorialRadius,
+                polSquared = this.polarRadius * this.polarRadius;
 
-            result[0] = cosLat * sinLon;
-            result[1] = sinLat;
-            result[2] = cosLat * cosLon;
+            result[0] = cosLat * sinLon / eqSquared;
+            result[1] = (1 - this.eccentricitySquared) * sinLat / polSquared;
+            result[2] = cosLat * cosLon / eqSquared;
 
             return result.normalize();
         };


### PR DESCRIPTION
- The implementation of screen credit hyperlinks causes several bugs in WebWorldWind's examples.
- Adding a ClickRecognizer and TapRecognizer to BasicWorldWindowController prevented recognizers in the examples from detecting clicks and taps.
- Additionally, applications making use of ClickRecognizer or TapRecognizer would be affected by this behavior, so we're rolling back the change until this issue can be addressed.

Fixes #721
Fixes #723