### PR TITLE
Improved Collada rendering

### DIFF
--- a/src/formats/collada/ColladaMesh.js
+++ b/src/formats/collada/ColladaMesh.js
@@ -166,6 +166,7 @@ define(['./ColladaUtils'], function (ColladaUtils) {
         var indicesArray = [];
         var pos = 0;
         var indexedRendering = false;
+        var isUint32 = false;
 
         for (var i = 0; i < count; i++) {
 
@@ -215,11 +216,20 @@ define(['./ColladaUtils'], function (ColladaUtils) {
                         firstIndex = currentIndex;
                     }
                     if (k > 2 * maxOffset) {
+                        if (firstIndex > 65535) {
+                            isUint32 = true;
+                        }
+                        if (prevIndex > 65535) {
+                            isUint32 = true;
+                        }
                         indicesArray.push(firstIndex);
                         indicesArray.push(prevIndex);
                     }
                 }
 
+                if (currentIndex > 65535) {
+                    isUint32 = true;
+                }
                 indicesArray.push(currentIndex);
                 pos += maxOffset;
 
@@ -229,10 +239,16 @@ define(['./ColladaUtils'], function (ColladaUtils) {
         var mesh = {
             vertices: new Float32Array(inputs[0][1]),
             indexedRendering: indexedRendering,
+            is32BitIndices: false,
             material: material
         };
 
-        this.transformMeshInfo(mesh, inputs, indicesArray);
+        if (mesh.indexedRendering) {
+            mesh.indices = isUint32 ? new Uint32Array(indicesArray) : new Uint16Array(indicesArray);
+            mesh.is32BitIndices = isUint32;
+        }
+
+        this.transformMeshInfo(mesh, inputs);
 
         return mesh;
 
@@ -294,9 +310,8 @@ define(['./ColladaUtils'], function (ColladaUtils) {
      * Internal. Applications should not call this function.
      * @param {Object} mesh The mesh that will be returned.
      * @param {Array} inputs The array containing the inputs of the mesh.
-     * @param {Number[]} indicesArray An array containing the indices.
      */
-    ColladaMesh.prototype.transformMeshInfo = function (mesh, inputs, indicesArray) {
+    ColladaMesh.prototype.transformMeshInfo = function (mesh, inputs) {
         var translator = {
             "normal": "normals",
             "texcoord": "uvs"
@@ -324,10 +339,6 @@ define(['./ColladaUtils'], function (ColladaUtils) {
             if (name === 'uvs') {
                 mesh.isClamp = ColladaUtils.getTextureType(data);
             }
-        }
-
-        if (mesh.indexedRendering) {
-            mesh.indices = new Uint16Array(indicesArray);
         }
 
         return mesh;

--- a/src/formats/collada/ColladaScene.js
+++ b/src/formats/collada/ColladaScene.js
@@ -899,27 +899,22 @@ define([
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.initializeUintExtension = function (dc) {
-            if (!this._uintExtCacheKey) {
-                this._uintExtCacheKey = dc.gpuResourceCache.generateCacheKey();
+            var ext = dc.gpuResourceCache.resourceForKey(ColladaScene._uintExtCacheKey);
+
+            if (ext) {
+                this._hasUintExt = true;
             }
-
-            var ext = dc.gpuResourceCache.resourceForKey(this._uintExtCacheKey);
-            var extensionInCache = !!ext;
-
-            if (extensionInCache === this._hasUintExt) {
-                return;
-            }
-
-            this._hasUintExt = false;
-
-            if (!ext) {
+            else {
+                this._hasUintExt = false;
                 ext = dc.currentGlContext.getExtension('OES_element_index_uint');
                 if (ext) {
-                    dc.gpuResourceCache.putResource(this._uintExtCacheKey, ext, 1);
+                    dc.gpuResourceCache.putResource(ColladaScene._uintExtCacheKey, ext, 1);
                     this._hasUintExt = true;
                 }
             }
         };
+
+        ColladaScene._uintExtCacheKey = 'uintExtCacheKey';
 
         return ColladaScene;
 

--- a/src/formats/collada/ColladaScene.js
+++ b/src/formats/collada/ColladaScene.js
@@ -50,7 +50,6 @@ define([
          * info needed to render the scene.
          */
         var ColladaScene = function (position, sceneData) {
-
             if (!position) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "ColladaScene", "constructor", "missingPosition"));
@@ -95,21 +94,36 @@ define([
             this._nodesToHide = [];
             this._hideNodes = false;
 
-            this.setSceneData(sceneData);
-
             // Documented in defineProperties below.
             this._placePoint = new Vec3(0, 0, 0);
 
             // Documented in defineProperties below.
             this._transformationMatrix = Matrix.fromIdentity();
+            this._mvpMatrix = Matrix.fromIdentity();
 
             // Documented in defineProperties below.
+            this._normalTransformMatrix = Matrix.fromIdentity();
             this._normalMatrix = Matrix.fromIdentity();
-
             this._texCoordMatrix = Matrix.fromIdentity().setToUnitYFlip();
 
+            //Internal. Intentionally not documented.
+            this._entities = [];
+
+            //Internal. Intentionally not documented.
             this._activeTexture = null;
 
+            //Internal. Intentionally not documented.
+            this._scratchVector = new Vec3(0, 0, 0);
+            this._scratchColor = new Color(1, 1, 1, 1);
+
+            //Internal. Intentionally not documented.
+            this._vboCacheKey = '';
+            this._iboCacheKey = '';
+            this._uintExtCacheKey = '';
+
+            this._hasUintExt = null;
+
+            this.setSceneData(sceneData);
         };
 
         ColladaScene.prototype = Object.create(Renderable.prototype);
@@ -442,18 +456,74 @@ define([
         // Internal. Intentionally not documented.
         ColladaScene.prototype.setSceneData = function (sceneData) {
             if (sceneData) {
-                this.nodes = sceneData.root.children;
-                this.meshes = sceneData.meshes;
-                this.materials = sceneData.materials;
-                this.images = sceneData.images;
-                this.upAxis = sceneData.metadata.up_axis;
-                this.dirPath = sceneData.dirPath;
+                this._nodes = sceneData.root.children;
+                this._meshes = sceneData.meshes;
+                this._materials = sceneData.materials;
+                this._images = sceneData.images;
+                this._upAxis = sceneData.metadata.up_axis;
+                this._dirPath = sceneData.dirPath;
+
+                this.flattenModel();
+            }
+        };
+
+        // Internal. Intentionally not documented.
+        ColladaScene.prototype.flattenModel = function () {
+            for (var i = 0, nodesLen = this._nodes.length; i < nodesLen; i++) {
+                this.flattenNode(this._nodes[i]);
+            }
+
+            this._entities.sort(function (a, b) {
+                var va = (a.imageKey === null) ? "" : "" + a,
+                    vb = (b.imageKey === null) ? "" : "" + b;
+                return va > vb ? 1 : (va === vb ? 0 : -1);
+            });
+        };
+
+        // Internal. Intentionally not documented.
+        ColladaScene.prototype.flattenNode = function (node) {
+            if (node.mesh) {
+                var meshKey = node.mesh;
+                var buffers = this._meshes[meshKey].buffers;
+
+                for (var i = 0, bufLen = buffers.length; i < bufLen; i++) {
+                    var materialBuf = buffers[i].material;
+
+                    for (var j = 0; j < node.materials.length; j++) {
+                        if (materialBuf === node.materials[j].symbol) {
+                            var materialKey = node.materials[j].id;
+                            break;
+                        }
+                    }
+
+                    var material = this._materials[materialKey];
+                    var imageKey = null;
+                    var hasTexture = material && material.textures && buffers[i].uvs && buffers[i].uvs.length > 0;
+                    if (hasTexture) {
+                        if (material.textures.diffuse) {
+                            imageKey = material.textures.diffuse.mapId;
+                        }
+                        else if (material.textures.reflective) {
+                            imageKey = material.textures.reflective.mapId;
+                        }
+                    }
+
+                    this._entities.push({
+                        mesh: buffers[i],
+                        material: material,
+                        node: node,
+                        imageKey: imageKey
+                    });
+                }
+            }
+
+            for (var k = 0; k < node.children.length; k++) {
+                this.flattenNode(node.children[k]);
             }
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.render = function (dc) {
-
             var orderedScene;
             var frustum = dc.frustumInModelCoordinates;
 
@@ -482,56 +552,55 @@ define([
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.makeOrderedRenderable = function (dc) {
+            dc.surfacePointForMode(this._position.latitude, this._position.longitude, this._position.altitude,
+                this._altitudeMode, this._placePoint);
 
-            dc.surfacePointForMode(this.position.latitude, this.position.longitude, this.position.altitude,
-                this.altitudeMode, this.placePoint);
-
-            this.eyeDistance = dc.eyePoint.distanceTo(this.placePoint);
+            this.eyeDistance = dc.eyePoint.distanceTo(this._placePoint);
 
             return this;
-
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.renderOrdered = function (dc) {
-
             this.drawOrderedScene(dc);
 
             if (dc.pickingMode) {
-                var po = new PickedObject(this.pickColor.clone(), this,
-                    this.position, this.layer, false);
-
+                var po = new PickedObject(this.pickColor.clone(), this, this._position, this.layer, false);
                 dc.resolvePick(po);
             }
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.drawOrderedScene = function (dc) {
-
-            this.beginDrawing(dc);
-
             try {
-                this.doDrawOrderedScene(dc);
+                this.beginDrawing(dc);
             }
             finally {
                 this.endDrawing(dc);
             }
-
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.beginDrawing = function (dc) {
-
             var gl = dc.currentGlContext;
+            var gpuResourceCache = dc.gpuResourceCache;
+
+            var vboId = gpuResourceCache.resourceForKey(this._vboCacheKey);
+            var iboId = gpuResourceCache.resourceForKey(this._iboCacheKey);
+
+            if (!vboId) {
+                this.setupBuffers(dc);
+                vboId = gpuResourceCache.resourceForKey(this._vboCacheKey);
+                iboId = gpuResourceCache.resourceForKey(this._iboCacheKey);
+            }
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, vboId);
+            if (iboId) {
+                gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, iboId);
+            }
 
             dc.findAndBindProgram(BasicTextureProgram);
-
-            gl.enable(gl.CULL_FACE);
-            gl.enable(gl.DEPTH_TEST);
-        };
-
-        // Internal. Intentionally not documented.
-        ColladaScene.prototype.doDrawOrderedScene = function (dc) {
+            gl.enableVertexAttribArray(0);
 
             if (dc.pickingMode) {
                 this.pickColor = dc.uniquePickColor();
@@ -539,117 +608,192 @@ define([
 
             this.computeTransformationMatrix(dc.globe);
 
-            for (var i = 0, nodesLen = this.nodes.length; i < nodesLen; i++) {
-                this.traverseNodeTree(dc, this.nodes[i]);
+            for (var i = 0, len = this._entities.length; i < len; i++) {
+                var mustRenderNode = this.mustRenderNode(this._entities[i].node.id);
+                if (mustRenderNode) {
+                    this.draw(dc, this._entities[i]);
+                }
             }
         };
 
         // Internal. Intentionally not documented.
-        ColladaScene.prototype.traverseNodeTree = function (dc, node) {
+        ColladaScene.prototype.setupBuffers = function (dc) {
+            var gl = dc.currentGlContext;
+            var sizeOfFloat32 = Float32Array.BYTES_PER_ELEMENT || 4;
+            var sizeOfUint16 = Uint16Array.BYTES_PER_ELEMENT || 2;
+            var sizeOfUint32 = Uint32Array.BYTES_PER_ELEMENT || 4;
+            var is32BitIndices = false;
+            var numIndices = 0;
+            var numVertices = 0;
 
-            var renderNode = this.mustRenderNode(node.id);
-
-            if (renderNode) {
-
-                if (node.mesh) {
-                    var meshKey = node.mesh;
-                    var buffers = this.meshes[meshKey].buffers;
-
-                    for (var i = 0, bufLen = buffers.length; i < bufLen; i++) {
-
-                        var materialBuf = buffers[i].material;
-
-                        for (var j = 0; j < node.materials.length; j++) {
-                            if (materialBuf === node.materials[j].symbol) {
-                                var materialKey = node.materials[j].id;
-                                break;
-                            }
-                        }
-
-                        var material = this.materials[materialKey];
-
-                        this.draw(dc, buffers[i], material, node.worldMatrix, node.normalMatrix);
+            for (var i = 0, len = this._entities.length; i < len; i++) {
+                var mesh = this._entities[i].mesh;
+                if (mesh.indexedRendering) {
+                    numIndices += mesh.indices.length;
+                    if (mesh.indices instanceof Uint32Array) {
+                        is32BitIndices = true;
                     }
                 }
-
-                for (var k = 0; k < node.children.length; k++) {
-                    this.traverseNodeTree(dc, node.children[k]);
+                numVertices += mesh.vertices.length;
+                if (this._entities[i].imageKey) {
+                    numVertices += mesh.uvs.length;
+                }
+                if (mesh.normals && mesh.normals.length) {
+                    numVertices += mesh.normals.length;
                 }
             }
 
+            var vbo = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, vbo);
+            gl.bufferData(gl.ARRAY_BUFFER, numVertices * sizeOfFloat32, gl.STATIC_DRAW);
+
+            var offset = 0;
+            for (i = 0, len = this._entities.length; i < len; i++) {
+                var data = this._entities[i].mesh.vertices;
+                this._entities[i].vertexOffset = offset;
+                gl.bufferSubData(gl.ARRAY_BUFFER, offset * sizeOfFloat32, data);
+                offset += data.length;
+            }
+
+            for (i = 0, len = this._entities.length; i < len; i++) {
+                if (this._entities[i].imageKey) {
+                    data = this._entities[i].mesh.uvs;
+                    this._entities[i].uvOffset = offset;
+                    gl.bufferSubData(gl.ARRAY_BUFFER, offset * sizeOfFloat32, data);
+                    offset += data.length;
+                }
+            }
+
+            for (i = 0, len = this._entities.length; i < len; i++) {
+                data = data = this._entities[i].mesh.normals;
+                if (data && data.length) {
+                    this._entities[i].normalOffset = offset;
+                    gl.bufferSubData(gl.ARRAY_BUFFER, offset * sizeOfFloat32, data);
+                    offset += data.length;
+                }
+            }
+
+            var indexSize = sizeOfUint16;
+            var indexBufferSize = numIndices * indexSize;
+            if (is32BitIndices) {
+                this.initializeUintExtension(dc);
+
+                if (!this._hasUintExt) {
+                    Logger.log(Logger.LEVEL_SEVERE,
+                        'The 3D model is too big and might not render properly. \n' +
+                        'The browser does not support the "OES_element_index_uint" extension, ' +
+                        'required to render large models.'
+                    );
+                }
+                else {
+                    indexSize = sizeOfUint32;
+                    indexBufferSize = numIndices * indexSize;
+                }
+            }
+
+            if (numIndices) {
+                var ibo = gl.createBuffer();
+                gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, ibo);
+                gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, indexBufferSize, gl.STATIC_DRAW);
+
+                offset = 0;
+                for (i = 0, len = this._entities.length; i < len; i++) {
+                    mesh = this._entities[i].mesh;
+                    if (mesh.indexedRendering) {
+                        data = mesh.indices;
+                        if (data instanceof Uint32Array && !this._hasUintExt) {
+                            data = new Uint16Array(data);
+                        }
+                        this._entities[i].indexOffset = offset;
+                        this._entities[i].indexSize = indexSize;
+                        gl.bufferSubData(gl.ELEMENT_ARRAY_BUFFER, offset * indexSize, data);
+                        offset += data.length;
+                    }
+                }
+            }
+
+            this._vboCacheKey = dc.gpuResourceCache.generateCacheKey();
+            dc.gpuResourceCache.putResource(this._vboCacheKey, vbo, numVertices * sizeOfFloat32);
+
+            if (numIndices) {
+                this._iboCacheKey = dc.gpuResourceCache.generateCacheKey();
+                dc.gpuResourceCache.putResource(this._iboCacheKey, ibo, indexBufferSize);
+            }
         };
 
         // Internal. Intentionally not documented.
-        ColladaScene.prototype.draw = function (dc, buffers, material, nodeWorldMatrix, nodeNormalMatrix) {
+        ColladaScene.prototype.draw = function (dc, entity) {
+            var gl = dc.currentGlContext;
+            var program = dc.currentProgram;
+            var gpuResourceCache = dc.gpuResourceCache;
 
-            var gl = dc.currentGlContext,
-                program = dc.currentProgram,
-                vboId;
+            var buffers = entity.mesh;
+            var material = entity.material;
 
-            this.applyVertices(dc, buffers);
+            var nodeWorldMatrix = entity.node.worldMatrix;
+            var nodeNormalMatrix = entity.node.normalMatrix;
 
-            program.loadTextureEnabled(gl, false);
+            var hasLighting = buffers.normals && buffers.normals.length;
+
+            var imageKey = entity.imageKey;
 
             this.applyColor(dc, material);
 
-            var hasTexture = (material && material.textures != null && buffers.uvs && buffers.uvs.length > 0);
-            if (hasTexture) {
-                this.applyTexture(dc, buffers, material);
+            if (imageKey) {
+                var imagePath = this._useTexturePaths ? this._images[imageKey].path : this._images[imageKey].filename;
+                var textureCacheKey = this._dirPath + imagePath;
+                this._activeTexture = gpuResourceCache.resourceForKey(textureCacheKey);
+                if (!this._activeTexture) {
+                    var wrapMode = buffers.isClamp ? gl.CLAMP_TO_EDGE : gl.REPEAT;
+                    this._activeTexture = gpuResourceCache.retrieveTexture(gl, textureCacheKey, wrapMode);
+                }
+                var textureBound = this._activeTexture && this._activeTexture.bind(dc);
+                if (textureBound) {
+                    program.loadTextureEnabled(gl, true);
+                    gl.vertexAttribPointer(2, 2, gl.FLOAT, false, 8, entity.uvOffset * 4);
+                    gl.enableVertexAttribArray(2);
+                    program.loadModulateColor(gl, dc.pickingMode);
+                }
+                else {
+                    program.loadTextureEnabled(gl, false);
+                    gl.disableVertexAttribArray(2);
+                }
+            }
+            else {
+                program.loadTextureEnabled(gl, false);
+                gl.disableVertexAttribArray(2);
             }
 
-            var hasLighting = (buffers.normals != null && buffers.normals.length > 0);
             if (hasLighting && !dc.pickingMode) {
-                this.applyLighting(dc, buffers);
+                program.loadApplyLighting(gl, 1);
+                gl.vertexAttribPointer(1, 3, gl.FLOAT, false, 12, entity.normalOffset * 4);
+                gl.enableVertexAttribArray(1);
+            }
+            else {
+                program.loadApplyLighting(gl, 0);
+                gl.disableVertexAttribArray(1);
             }
 
-            this.applyMatrix(dc, hasLighting, hasTexture, nodeWorldMatrix, nodeNormalMatrix);
+            this.applyMatrix(dc, hasLighting, textureCacheKey, nodeWorldMatrix, nodeNormalMatrix);
+
+            gl.vertexAttribPointer(0, 3, gl.FLOAT, false, 12, entity.vertexOffset * 4);
 
             if (buffers.indexedRendering) {
-                this.applyIndices(dc, buffers);
-                gl.drawElements(gl.TRIANGLES, buffers.indices.length, gl.UNSIGNED_SHORT, 0);
+                var indexOffsetBytes = entity.indexOffset * entity.indexSize;
+                if (buffers.is32BitIndices && this._hasUintExt) {
+                    gl.drawElements(gl.TRIANGLES, buffers.indices.length, gl.UNSIGNED_INT, indexOffsetBytes);
+                }
+                else {
+                    gl.drawElements(gl.TRIANGLES, buffers.indices.length, gl.UNSIGNED_SHORT, indexOffsetBytes);
+                }
             }
             else {
                 gl.drawArrays(gl.TRIANGLES, 0, Math.floor(buffers.vertices.length / 3));
             }
-
-            this.resetDraw(dc, hasLighting, hasTexture);
-
-        };
-
-        // Internal. Intentionally not documented.
-        ColladaScene.prototype.applyVertices = function (dc, buffers) {
-
-            var gl = dc.currentGlContext,
-                program = dc.currentProgram,
-                vboId;
-
-            if (!buffers.verticesVboCacheKey) {
-                buffers.verticesVboCacheKey = dc.gpuResourceCache.generateCacheKey();
-            }
-
-            vboId = dc.gpuResourceCache.resourceForKey(buffers.verticesVboCacheKey);
-            if (!vboId) {
-                vboId = gl.createBuffer();
-                dc.gpuResourceCache.putResource(buffers.verticesVboCacheKey, vboId,
-                    buffers.vertices.length);
-                buffers.refreshVertexBuffer = true;
-            }
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboId);
-            if (buffers.refreshVertexBuffer) {
-                gl.bufferData(gl.ARRAY_BUFFER, buffers.vertices, gl.STATIC_DRAW);
-                dc.frameStatistics.incrementVboLoadCount(1);
-                buffers.refreshVertexBuffer = false;
-            }
-
-            gl.enableVertexAttribArray(program.vertexPointLocation);
-            gl.vertexAttribPointer(program.vertexPointLocation, 3, gl.FLOAT, false, 0, 0);
-
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.applyColor = function (dc, material) {
-
             var gl = dc.currentGlContext,
                 program = dc.currentProgram;
 
@@ -672,120 +816,30 @@ define([
                 a = diffuse[3] != null ? diffuse[3] : 1;
             }
 
-            var color = new Color(r, g, b, a);
+            this._scratchColor.set(r, g, b, a);
             opacity = a * this.layer.opacity;
             gl.depthMask(opacity >= 1 || dc.pickingMode);
-            program.loadColor(gl, dc.pickingMode ? this.pickColor : color);
+            program.loadColor(gl, dc.pickingMode ? this.pickColor : this._scratchColor);
             program.loadOpacity(gl, dc.pickingMode ? (opacity > 0 ? 1 : 0) : opacity);
         };
 
         // Internal. Intentionally not documented.
-        ColladaScene.prototype.applyTexture = function (dc, buffers, material) {
-
-            var textureBound, vboId,
-                gl = dc.currentGlContext,
-                program = dc.currentProgram,
-                wrapMode;
-
-            if (material.textures.diffuse) {
-                var imageKey = material.textures.diffuse.mapId;
-            }
-            else {
-                imageKey = material.textures.reflective.mapId;
-            }
-
-            var image = this.useTexturePaths ? this.images[imageKey].path : this.images[imageKey].filename;
-
-            this._activeTexture = dc.gpuResourceCache.resourceForKey(this.dirPath + image + "");
-            if (!this._activeTexture) {
-                wrapMode = buffers.isClamp ? gl.CLAMP_TO_EDGE : gl.REPEAT;
-                this._activeTexture = dc.gpuResourceCache.retrieveTexture(gl, this.dirPath + image + "", wrapMode);
-            }
-            textureBound = this._activeTexture && this._activeTexture.bind(dc);
-
-            if (textureBound) {
-                if (!buffers.texCoordsVboCacheKey) {
-                    buffers.texCoordsVboCacheKey = dc.gpuResourceCache.generateCacheKey();
-                }
-
-                vboId = dc.gpuResourceCache.resourceForKey(buffers.texCoordsVboCacheKey);
-                if (!vboId) {
-                    vboId = gl.createBuffer();
-                    dc.gpuResourceCache.putResource(buffers.texCoordsVboCacheKey, vboId, buffers.uvs.length);
-                    buffers.refreshTexCoordBuffer = true;
-                }
-
-                gl.bindBuffer(gl.ARRAY_BUFFER, vboId);
-                if (buffers.refreshTexCoordBuffer) {
-                    gl.bufferData(gl.ARRAY_BUFFER, buffers.uvs, gl.STATIC_DRAW);
-                    dc.frameStatistics.incrementVboLoadCount(1);
-                    buffers.refreshTexCoordBuffer = false;
-                }
-
-                program.loadTextureEnabled(gl, true);
-                gl.enableVertexAttribArray(program.vertexTexCoordLocation);
-                gl.vertexAttribPointer(program.vertexTexCoordLocation, 2, gl.FLOAT, false, 0, 0);
-                program.loadTextureUnit(gl, gl.TEXTURE0);
-                program.loadModulateColor(gl, dc.pickingMode);
-            }
-        };
-
-        // Internal. Intentionally not documented.
-        ColladaScene.prototype.applyLighting = function (dc, buffers) {
-
-            var vboId,
-                gl = dc.currentGlContext,
-                program = dc.currentProgram;
-
-            program.loadApplyLighting(gl, true);
-            if (!buffers.normalsVboCacheKey) {
-                buffers.normalsVboCacheKey = dc.gpuResourceCache.generateCacheKey();
-            }
-
-            vboId = dc.gpuResourceCache.resourceForKey(buffers.normalsVboCacheKey);
-            if (!vboId) {
-                vboId = gl.createBuffer();
-                dc.gpuResourceCache.putResource(buffers.normalsVboCacheKey, vboId, buffers.normals.length);
-                buffers.refreshNormalBuffer = true;
-            }
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboId);
-            if (buffers.refreshNormalBuffer) {
-                gl.bufferData(gl.ARRAY_BUFFER, buffers.normals, gl.STATIC_DRAW);
-                dc.frameStatistics.incrementVboLoadCount(1);
-                buffers.refreshNormalBuffer = false;
-            }
-
-            gl.enableVertexAttribArray(program.normalVectorLocation);
-            gl.vertexAttribPointer(program.normalVectorLocation, 3, gl.FLOAT, false, 0, 0);
-        };
-
-        // Internal. Intentionally not documented.
         ColladaScene.prototype.applyMatrix = function (dc, hasLighting, hasTexture, nodeWorldMatrix, nodeNormalMatrix) {
+            this._mvpMatrix.copy(dc.modelviewProjection);
+            this._mvpMatrix.multiplyMatrix(this._transformationMatrix);
 
-            var mvpMatrix = Matrix.fromIdentity();
-
-            mvpMatrix.copy(dc.modelviewProjection);
-
-            mvpMatrix.multiplyMatrix(this.transformationMatrix);
-
-            if (nodeWorldMatrix && this.localTransforms) {
-                mvpMatrix.multiplyMatrix(nodeWorldMatrix);
+            if (nodeWorldMatrix && this._localTransforms) {
+                this._mvpMatrix.multiplyMatrix(nodeWorldMatrix);
             }
 
             if (hasLighting && !dc.pickingMode) {
-
-                var normalMatrix = Matrix.fromIdentity();
-
-                normalMatrix.copy(dc.modelviewNormalTransform);
-
-                normalMatrix.multiplyMatrix(this.normalMatrix);
-
-                if (nodeNormalMatrix && this.localTransforms) {
-                    normalMatrix.multiplyMatrix(nodeNormalMatrix);
+                this._normalMatrix.copy(dc.modelviewNormalTransform);
+                this._normalMatrix.multiplyMatrix(this._normalTransformMatrix);
+                if (nodeNormalMatrix && this._localTransforms) {
+                    this._normalMatrix.multiplyMatrix(nodeNormalMatrix);
                 }
 
-                dc.currentProgram.loadModelviewInverse(dc.currentGlContext, normalMatrix);
+                dc.currentProgram.loadModelviewInverse(dc.currentGlContext, this._normalMatrix);
             }
 
             if (hasTexture && this._activeTexture) {
@@ -793,100 +847,78 @@ define([
                 this._activeTexture = null;
             }
 
-            dc.currentProgram.loadModelviewProjection(dc.currentGlContext, mvpMatrix);
-
-        };
-
-        // Internal. Intentionally not documented.
-        ColladaScene.prototype.applyIndices = function (dc, buffers) {
-
-            var gl = dc.currentGlContext,
-                vboId;
-
-            if (!buffers.indicesVboCacheKey) {
-                buffers.indicesVboCacheKey = dc.gpuResourceCache.generateCacheKey();
-            }
-
-            vboId = dc.gpuResourceCache.resourceForKey(buffers.indicesVboCacheKey);
-            if (!vboId) {
-                vboId = gl.createBuffer();
-                dc.gpuResourceCache.putResource(buffers.indicesVboCacheKey, vboId, buffers.indices.length);
-                buffers.refreshIndicesBuffer = true;
-            }
-
-            gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, vboId);
-            if (buffers.refreshIndicesBuffer) {
-                gl.bufferData(gl.ELEMENT_ARRAY_BUFFER, buffers.indices, gl.STATIC_DRAW);
-                dc.frameStatistics.incrementVboLoadCount(1);
-                buffers.refreshIndicesBuffer = false;
-            }
-
-        };
-
-        // Internal. Intentionally not documented.
-        ColladaScene.prototype.resetDraw = function (dc, hasLighting, hasTexture) {
-
-            var gl = dc.currentGlContext,
-                program = dc.currentProgram;
-
-            if (hasLighting && !dc.pickingMode) {
-                program.loadApplyLighting(gl, false);
-                gl.disableVertexAttribArray(program.normalVectorLocation);
-            }
-
-            if (hasTexture) {
-                gl.disableVertexAttribArray(program.vertexTexCoordLocation);
-            }
-
-            gl.disableVertexAttribArray(program.vertexPointLocation);
+            dc.currentProgram.loadModelviewProjection(dc.currentGlContext, this._mvpMatrix);
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.endDrawing = function (dc) {
-            dc.bindProgram(null);
+            var gl = dc.currentGlContext;
+            var program = dc.currentProgram;
+
+            gl.disableVertexAttribArray(1);
+            gl.disableVertexAttribArray(2);
+            program.loadApplyLighting(gl, 0);
+            program.loadTextureEnabled(gl, false);
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.computeTransformationMatrix = function (globe) {
+            this._transformationMatrix.setToIdentity();
 
-            this.transformationMatrix = Matrix.fromIdentity();
+            this._transformationMatrix.multiplyByLocalCoordinateTransform(this._placePoint, globe);
 
-            this.transformationMatrix.multiplyByLocalCoordinateTransform(this.placePoint, globe);
+            this._transformationMatrix.multiplyByRotation(1, 0, 0, this._xRotation);
+            this._transformationMatrix.multiplyByRotation(0, 1, 0, this._yRotation);
+            this._transformationMatrix.multiplyByRotation(0, 0, 1, this._zRotation);
 
-            this.transformationMatrix.multiplyByRotation(1, 0, 0, this.xRotation);
-            this.transformationMatrix.multiplyByRotation(0, 1, 0, this.yRotation);
-            this.transformationMatrix.multiplyByRotation(0, 0, 1, this.zRotation);
+            this._transformationMatrix.multiplyByScale(this._scale, this._scale, this._scale);
 
-            this.transformationMatrix.multiplyByScale(this.scale, this.scale, this.scale);
-
-            this.transformationMatrix.multiplyByTranslation(this.xTranslation, this.yTranslation, this.zTranslation);
+            this._transformationMatrix.multiplyByTranslation(this._xTranslation, this._yTranslation, this._zTranslation);
 
             this.computeNormalMatrix();
-
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.computeNormalMatrix = function () {
-
-            var rotAngles = new Vec3(0, 0, 0);
-
-            this.transformationMatrix.extractRotationAngles(rotAngles);
-
-            this.normalMatrix = Matrix.fromIdentity();
-
-            this.normalMatrix.multiplyByRotation(-1, 0, 0, rotAngles[0]);
-            this.normalMatrix.multiplyByRotation(0, -1, 0, rotAngles[1]);
-            this.normalMatrix.multiplyByRotation(0, 0, -1, rotAngles[2]);
+            this._transformationMatrix.extractRotationAngles(this._scratchVector);
+            this._normalTransformMatrix.setToIdentity();
+            this._normalTransformMatrix.multiplyByRotation(-1, 0, 0, this._scratchVector[0]);
+            this._normalTransformMatrix.multiplyByRotation(0, -1, 0, this._scratchVector[1]);
+            this._normalTransformMatrix.multiplyByRotation(0, 0, -1, this._scratchVector[2]);
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.mustRenderNode = function (nodeId) {
             var draw = true;
-            if (this.hideNodes) {
-                var pos = this.nodesToHide.indexOf(nodeId);
+            if (this._hideNodes) {
+                var pos = this._nodesToHide.indexOf(nodeId);
                 draw = (pos === -1);
             }
             return draw;
+        };
+
+        // Internal. Intentionally not documented.
+        ColladaScene.prototype.initializeUintExtension = function (dc) {
+            if (!this._uintExtCacheKey) {
+                this._uintExtCacheKey = dc.gpuResourceCache.generateCacheKey();
+            }
+
+            var ext = dc.gpuResourceCache.resourceForKey(this._uintExtCacheKey);
+            var extensionInCache = !!ext;
+
+            if (extensionInCache === this._hasUintExt) {
+                return;
+            }
+
+            this._hasUintExt = false;
+
+            if (!ext) {
+                ext = dc.currentGlContext.getExtension('OES_element_index_uint');
+                if (ext) {
+                    dc.gpuResourceCache.putResource(this._uintExtCacheKey, ext, 1);
+                    this._hasUintExt = true;
+                }
+            }
         };
 
         return ColladaScene;

--- a/src/formats/collada/ColladaScene.js
+++ b/src/formats/collada/ColladaScene.js
@@ -455,6 +455,7 @@ define([
         ColladaScene.prototype.render = function (dc) {
 
             var orderedScene;
+            var frustum = dc.frustumInModelCoordinates;
 
             if (!this.enabled) {
                 return;
@@ -465,6 +466,10 @@ define([
             }
 
             if (!orderedScene) {
+                return;
+            }
+
+            if (!frustum.containsPoint(this._placePoint)) {
                 return;
             }
 


### PR DESCRIPTION
### Description of the Change
**1. Flatten the node tree structure and merge all geometry in one or two buffers.**
This creates at most 2 gpu buffers per model rather than 4 per mesh.
One buffer is created for attributes(positions, normals and texture coordinates) and one buffer for indices.
Other than positions, the rest are optional and this method does not require that meshes have normals, texture coordinates or indices.
This includes mixing all sort of combinations, some meshes may only have positions, some have all the attributes and so on.

**2. Frustum culling.**
Frustum culling is done by the position of the model, rather than the bounding box.
This has the advantage that it’s faster, but it will cull the model at the edge of the frustum if the position is outside the frustum but some part of the model is still visible.
In my opinion this is not noticeable and outweighs having to compute the bbox and test against it.

**3. Reduced object initialisation during rendering.**
Vec3, Matrix and Color instances where created during rendering and then discarded.
They are now initialized once in the constructor and then reused.

**4. Added support for large models.**
Support for large models was added by using the ```OES_element_index_uint extension```.
This extension has good support and is strait forward to implement.
In case the model requires the extension and the extension is not available, an error is logged to the console and rendering proceeds as normal. The model will most likely not be rendered correctly, some parts will be missing.

### Benefits
Faster rendering of collada models.
Support for large models.

### Potential Drawbacks
None.

### Applicable Issues
#631 