### PR TITLE
Updated BlueMarble and Landsat layers to capture their full resolution

### DIFF
--- a/src/layer/BMNGLandsatLayer.js
+++ b/src/layer/BMNGLandsatLayer.js
@@ -37,8 +37,9 @@ define([
          * @classdesc Displays a combined Blue Marble and Landsat image layer that spans the entire globe.
          */
         var BMNGLandsatLayer = function () {
+            // This LevelSet configuration captures the Landsat resolution of 1.38889E-04 degrees/pixel
             TiledImageLayer.call(this,
-                Sector.FULL_SPHERE, new Location(45, 45), 10, "image/jpeg", "BMNGLandsat256", 256, 256);
+                Sector.FULL_SPHERE, new Location(45, 45), 12, "image/jpeg", "BMNGLandsat256", 256, 256);
 
             this.displayName = "Blue Marble & Landsat";
             this.pickEnabled = false;

--- a/src/layer/BMNGLayer.js
+++ b/src/layer/BMNGLayer.js
@@ -40,8 +40,9 @@ define([
          * or undefined.
          */
         var BMNGLayer = function (layerName) {
+            // This LevelSet configuration captures the Blue Marble resolution of 4.166666667E-03 degrees/pixel
             TiledImageLayer.call(this,
-                Sector.FULL_SPHERE, new Location(45, 45), 5, "image/jpeg", layerName || "BMNG256", 256, 256);
+                Sector.FULL_SPHERE, new Location(45, 45), 7, "image/jpeg", layerName || "BMNG256", 256, 256);
 
             this.displayName = "Blue Marble";
             this.pickEnabled = false;


### PR DESCRIPTION
- Blue Marble's native resolution is 4.166666667E-03 deg/pixel.
- Landsat's native resolution is 1.38889E-04 deg/pixel.
- Increased BMNGLayer's maximum resolution from 5.5E-0.3 deg/pixel to 1.4E-0.3 deg/pixel.
- Increased BMNGLandsatLayer's maximum resolution from 1.7E-0.4 deg/pixel to 4.3E-0.5 deg/pixel.
- Given the modest increase in resolution, this change has no effect on runtime performance.

Closes #772