### PR TITLE
Clarified console messages relating to WebGL support

### DIFF
--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -84,8 +84,7 @@ define([
         var WorldWindow = function (canvasElem, elevationModel) {
             if (!(window.WebGLRenderingContext)) {
                 throw new ArgumentError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor",
-                        "The specified canvas does not support WebGL."));
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor", "webglNotSupported"));
             }
 
             // Get the actual canvas element either directly or by ID.
@@ -105,6 +104,10 @@ define([
 
             // Create the WebGL context associated with the HTML canvas.
             var gl = this.createContext(canvas);
+            if (!gl) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "WorldWindow", "constructor", "webglNotSupported"));
+            }
 
             // Internal. Intentionally not documented.
             this.drawContext = new DrawContext(gl);
@@ -123,6 +126,9 @@ define([
 
             // Internal. Intentionally not documented.
             this.scratchProjection = Matrix.fromIdentity();
+
+            // Internal. Intentionally not documented.
+            this.hasStencilBuffer = gl.getContextAttributes().stencil;
 
             /**
              * The HTML canvas associated with this WorldWindow.
@@ -563,9 +569,6 @@ define([
             if (!gl) {
                 gl = canvas.getContext("experimental-webgl", glAttrs);
             }
-
-            var actualAttributes = gl.getContextAttributes();
-            this.hasStencilBuffer = actualAttributes.stencil;
 
             // uncomment to debug WebGL
             //var gl = WebGLDebugUtils.makeDebugContext(this.canvas.getContext("webgl"),

--- a/src/util/Logger.js
+++ b/src/util/Logger.js
@@ -161,7 +161,8 @@ define(function () {
             missingWebCoverageService: "The specified WebCoverageService is null or undefined.",
             missingWorldWindow: "The specified WorldWindow is null or undefined.",
             notYetImplemented: "This function is not yet implemented",
-            unsupportedVersion: "The specified version is not supported."
+            unsupportedVersion: "The specified version is not supported.",
+            webglNotSupported: "The browser does not support WebGL, or WebGL is disabled."
         }
     };
 


### PR DESCRIPTION
Changed the console message emitted during WorldWindow construction when a WebGL context cannot be created. These messages appear when the browser does not support WebGL, or when WebGL support has been disabled (either by the user, or by a group policy).

Old console message:

<img width="1131" alt="webgl message before" src="https://user-images.githubusercontent.com/14062862/42738918-4fc652ac-8841-11e8-8aba-46228e08f111.png">

New console message:

<img width="1131" alt="webgl message after" src="https://user-images.githubusercontent.com/14062862/42738919-5230ea84-8841-11e8-8832-322b39e9455e.png">