### PR TITLE
Recenter view and add missing metadata for new GeoTIFF example file

### DIFF
--- a/examples/GeoTiff.html
+++ b/examples/GeoTiff.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
     <script data-main="GeoTiff" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 
 </head>

--- a/examples/GeoTiff.html
+++ b/examples/GeoTiff.html
@@ -8,7 +8,6 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js" type="text/javascript"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/spin.js/2.3.2/spin.min.js"></script>
     <script data-main="GeoTiff" src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.1.17/require.min.js"></script>
 
 </head>

--- a/examples/GeoTiff.js
+++ b/examples/GeoTiff.js
@@ -50,8 +50,6 @@ requirejs(['./WorldWindShim',
 
         // Create GeoTiff layer and add it to the WorldWindow's layer list. Disabled until its image is loaded.
         var geoTiffLayer = new WorldWind.RenderableLayer("GeoTiff");
-        geoTiffLayer.enabled = false;
-        geoTiffLayer.showSpinner = true;
         wwd.addLayer(geoTiffLayer);
 
         var resourceUrl = "https://worldwind.arc.nasa.gov/web/examples/data/black_sea_rgb.tif";
@@ -72,13 +70,10 @@ requirejs(['./WorldWindShim',
 
             // Add the SurfaceImage to the GeoTiff layer and update the layer manager.
             geoTiffLayer.addRenderable(surfaceGeoTiff);
-            geoTiffLayer.enabled = true;
-            geoTiffLayer.showSpinner = false;
-            layerManager.synchronizeLayerList();
 
             // Redraw the WorldWindow and point the camera towards the imagery location.
             wwd.redraw();
-            wwd.goTo(new WorldWind.Position(43.69, 28.54, 55000));
+            wwd.goTo(new WorldWind.Position(43.80, 28.57, 30000));
         });
 
         // Create a layer manager for controlling layer visibility.

--- a/examples/GeoTiff.js
+++ b/examples/GeoTiff.js
@@ -50,6 +50,8 @@ requirejs(['./WorldWindShim',
 
         // Create GeoTiff layer and add it to the WorldWindow's layer list. Disabled until its image is loaded.
         var geoTiffLayer = new WorldWind.RenderableLayer("GeoTiff");
+        geoTiffLayer.enabled = false;
+        geoTiffLayer.showSpinner = true;
         wwd.addLayer(geoTiffLayer);
 
         var resourceUrl = "https://worldwind.arc.nasa.gov/web/examples/data/black_sea_rgb.tif";
@@ -70,6 +72,9 @@ requirejs(['./WorldWindShim',
 
             // Add the SurfaceImage to the GeoTiff layer and update the layer manager.
             geoTiffLayer.addRenderable(surfaceGeoTiff);
+            geoTiffLayer.enabled = true;
+            geoTiffLayer.showSpinner = false;
+            layerManager.synchronizeLayerList();
 
             // Redraw the WorldWindow and point the camera towards the imagery location.
             wwd.redraw();

--- a/src/formats/geotiff/GeoTiffMetadata.js
+++ b/src/formats/geotiff/GeoTiffMetadata.js
@@ -43,6 +43,9 @@ define([
             this._extraSamples = null;
 
             // Documented in defineProperties below.
+            this._imageDescription = null;
+
+            // Documented in defineProperties below.
             this._imageLength = null;
 
             // Documented in defineProperties below.
@@ -122,6 +125,9 @@ define([
 
             // Documented in defineProperties below.
             this._noData = null;
+
+            // Documented in defineProperties below.
+            this._metaData = null;
 
             // Documented in defineProperties below.
             this._bbox = null;
@@ -220,6 +226,21 @@ define([
 
                 set: function(value){
                     this._extraSamples = value;
+                }
+            },
+
+            /**
+             * Contains the image description.
+             * @memberof GeoTiffMetadata.prototype
+             * @type {String}
+             */
+            imageDescription: {
+                get: function () {
+                    return this._imageDescription;
+                },
+
+                set: function(value){
+                    this._imageDescription = value;
                 }
             },
 
@@ -592,6 +613,21 @@ define([
 
                 set: function(value){
                     this._noData = value;
+                }
+            },
+
+            /**
+             * Contains the METADATA value.
+             * @memberof GeoTiffMetadata.prototype
+             * @type {String}
+             */
+            metaData: {
+                get: function () {
+                    return this._metaData;
+                },
+
+                set: function(value){
+                    this._metaData = value;
                 }
             },
 

--- a/src/formats/geotiff/GeoTiffReader.js
+++ b/src/formats/geotiff/GeoTiffReader.js
@@ -813,6 +813,9 @@ define([
                     case TiffConstants.Tag.EXTRA_SAMPLES:
                         this.metadata.extraSamples = this.imageFileDirectories[0][i].getIFDEntryValue();
                         break;
+                    case TiffConstants.Tag.IMAGE_DESCRIPTION:
+                        this.metadata.imageDescription = this.imageFileDirectories[0][i].getIFDEntryValue()[0];
+                        break;
                     case TiffConstants.Tag.IMAGE_LENGTH:
                         this.metadata.imageLength = this.imageFileDirectories[0][i].getIFDEntryValue()[0];
                         break;
@@ -889,6 +892,9 @@ define([
                         break;
                     case GeoTiffConstants.Tag.MODEL_TIEPOINT:
                         this.metadata.modelTiepoint = this.imageFileDirectories[0][i].getIFDEntryValue();
+                        break;
+                    case GeoTiffConstants.Tag.GDAL_METADATA:
+                        this.metadata.noData = this.imageFileDirectories[0][i].getIFDEntryValue();
                         break;
                     case GeoTiffConstants.Tag.GDAL_NODATA:
                         this.metadata.noData = this.imageFileDirectories[0][i].getIFDEntryValue();

--- a/src/formats/geotiff/GeoTiffReader.js
+++ b/src/formats/geotiff/GeoTiffReader.js
@@ -894,7 +894,7 @@ define([
                         this.metadata.modelTiepoint = this.imageFileDirectories[0][i].getIFDEntryValue();
                         break;
                     case GeoTiffConstants.Tag.GDAL_METADATA:
-                        this.metadata.noData = this.imageFileDirectories[0][i].getIFDEntryValue();
+                        this.metadata.metaData = this.imageFileDirectories[0][i].getIFDEntryValue();
                         break;
                     case GeoTiffConstants.Tag.GDAL_NODATA:
                         this.metadata.noData = this.imageFileDirectories[0][i].getIFDEntryValue();


### PR DESCRIPTION
Once @pdavidc has published the new GeoTIFF file at https://worldwind.arc.nasa.gov/web/examples/data/black_sea_rgb.tif, please consider this change, which recenter the view on the example data.

The example file was reduced from 12MB to less than 1MB. It should thus load fine on any devices now.

Closes #730 
Closes #327