### PR TITLE
Correct the coordinates order of WKT shapes

### DIFF
--- a/src/formats/wkt/geom/WktObject.js
+++ b/src/formats/wkt/geom/WktObject.js
@@ -94,9 +94,9 @@ define([
      */
     WktObject.prototype.addCoordinates = function (coordinates) {
         if (this._is3d) {
-            this.coordinates.push(new Position(coordinates[0], coordinates[1], coordinates[2] || 0));
+            this.coordinates.push(new Position(coordinates[1], coordinates[0], coordinates[2] || 0));
         } else {
-            this.coordinates.push(new Location(coordinates[0], coordinates[1]));
+            this.coordinates.push(new Location(coordinates[1], coordinates[0]));
         }
     };
 


### PR DESCRIPTION
The coordinates in a WKT shape are ordered as “longitude latitude”.