### PR TITLE
Fix outline indices not being updated for GeographicMesh when positio…

### DIFF
--- a/src/shapes/GeographicMesh.js
+++ b/src/shapes/GeographicMesh.js
@@ -188,7 +188,7 @@ define([
                     this.reset();
 
                     this.meshIndices = null;
-                    this.outlineIndices = null;
+                    this.meshOutlineIndices = null;
                 }
             },
 


### PR DESCRIPTION
### Description of the Change
Fixes a typo in GeographicMesh that causes outlines to break when positions are updated.

### Why Should This Be In Core?
It fixes a bug in a core shape.

### Benefits
It fixes a bug.

### Potential Drawbacks
None.

### Applicable Issues
Outlines break when positions are updated on a GeographicMesh.