### PR TITLE
Suppress automated API doc deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,12 +21,12 @@ deploy:
     on:
       branch: develop
   # Publish API documentation to GitHub Pages
-  - provider: pages
-    github_token: $GITHUB_API_KEY
-    local_dir: build/dist/api-doc
-    skip_cleanup: true
-    on:
-      branch: develop
+  #- provider: pages
+  #  github_token: $GITHUB_API_KEY
+  #  local_dir: build/dist/api-doc
+  #  skip_cleanup: true
+  #  on:
+  #    branch: develop
   # Publish release artifacts to the npm repository
   - provider: npm
     email: $NPM_EMAIL


### PR DESCRIPTION
Temporarily suppress automated API doc deployment to GitHub Pages until the root cause of build errors can be identified and resolved.