### PR TITLE
Remove upper bound for tile imagery resolution.

### DIFF
--- a/src/util/Tile.js
+++ b/src/util/Tile.js
@@ -326,7 +326,7 @@ define([
                 distance = this.distanceTo(dc.eyePoint),
                 pixelSize = dc.pixelSizeAtDistance(distance);
 
-            return cellSize > Math.max(detailFactor * pixelSize, 0.5);
+            return cellSize > detailFactor * pixelSize;
         };
 
         /**


### PR DESCRIPTION
### Description of the Change

On the current develop branch, worldwind [limits the resolution of image tiles to 0.5m](https://github.com/NASAWorldWind/WebWorldWind/blob/develop/src/util/Tile.js#L329). When visualizing scenes which are low to the ground (such as geolocated vehicles) this can be insufficient resolution to view a scene in full detail. 

This PR removes the artificial limit in `mustSubdivide`, which in turn allows the layer providers to regain control over the maximum resolution they can support. For example, the Bing tiled image layer supports [23 levels of imagery](https://github.com/NASAWorldWind/WebWorldWind/blob/develop/src/layer/BingTiledImageLayer.js#L53), some of which are unavailable before this MR because `mustSubdivide` begins returning false before the higher levels are reached. A side-by-side comparison of using the `BingAerialLayer` before and after this MR is below:

| Current `develop` branch | This PR  |
| ----------------------------------- | -----------  |
| ![before](https://i.imgur.com/nQTKjG7.png)                          | ![after](https://i.imgur.com/ey8j2xl.png) |


### Why Should This Be In Core?
The current resolution limit is hard-coded in core, thus must be modified there.

### Benefits
The ability to render arbitrarily small scenes, which would commonly include situations such as geolocated vehicles and 3D renders of individual buildings.

### Potential Drawbacks
The current limit may be there to reduce accidental bandwidth usage. In this case I'd request that a  configurable option be included to set the minimum tile resolution to something other than 0.5.
