### PR TITLE
Add moveTo and getReferencePosition methods

### DIFF
--- a/src/shapes/Placemark.js
+++ b/src/shapes/Placemark.js
@@ -794,5 +794,15 @@ define([
                 && (!dc.pickingMode || this.enableLeaderLinePicking);
         };
 
+        // Internal use only. Intentionally not documented.
+        Placemark.prototype.getReferencePosition = function () {
+            return this.position;
+        };
+
+        // Internal use only. Intentionally not documented.
+        Placemark.prototype.moveTo = function (globe, position) {
+            this.position = position;
+        };
+
         return Placemark;
     });


### PR DESCRIPTION
### Description of the Change
Add moveTo and getReferencePosition methods in Placemark.

### Why Should This Be In Core?
Those methods are used in Shape editor.
Methods already implemented in all the shapes available in shape editor.

### Benefits
API offers an unified way  to manipulate shapes.

### Potential Drawbacks
None.
