### PR TITLE
bug: when calling pickShapesInRegion(), if there is a TriangleMesh in…

### DIFF
--- a/src/shapes/AbstractMesh.js
+++ b/src/shapes/AbstractMesh.js
@@ -493,6 +493,7 @@ define([
         };
 
         AbstractMesh.prototype.computePickPosition = function (dc) {
+            if(dc.pickRay == null) {return null;}
             var currentData = this.currentData,
                 line = dc.pickRay,
                 localLineOrigin = new Vec3(line.origin[0], line.origin[1], line.origin[2]).subtract(


### PR DESCRIPTION
… the pick region, the function fails and throws an exception. This is because "pickShapesInRegion()" uses a rectangle region to do picking, not a point. Instead, it makes a temporary frustum and checks if shapes are visible inside that frustum. This means that the pickRay property is null throughout the picking process. The "AbstractMesh.prototype.computePickPosition()" function will crash when the pickRay is null, but the result is only needed for normal "pick()". When using "pickShapesInRegion()", the result from computePickPosition() is ignored, and the temporary frustum is used instead. So we just need to add "if(dc.pickRay==null) {return null;}" to the top of the "AbstractMesh.prototype.computePickPosition()" function. This allows the code to move on and the pickShapesInRegion() function can complete successfully. This problem does not happen with WorldWind.Polygons, but does happen with WorldWind.TriangleMesh, and probably everything that inherits from WorldWind.AbstractMesh.


### Description of the Change
One line of code at the top of AbstractMesh.prototype.computePickPosition().
if(dc.pickRay==null) {return null;}

### Why Should This Be In Core?
pickShapesInRegion fails to pick TriangleMesh objects without this bug fix.

### Benefits
pickShapesInRegion now properly adds TrianlgeMesh objects to the returned pickList.

### Potential Drawbacks
Though unfathomable to me, it is possible that someone actually wanted this function to throw an exception and cause the AbstractMesh.prototype.doRenderOrdered() function to fail. If so, I will need to find another way to fix this bug.

### Applicable Issues
pickShapesInRegion() not working with TriangleMesh.


Here is a screenshot before the bug fix. After calling pickShapesInRegion with a region containing the aircraft TriangleMesh, I get no results in the returned pickList.
![without bugfix](https://user-images.githubusercontent.com/3943457/47817611-196dfd80-dd24-11e8-9423-088df337f6a1.png)


Here is a screenshot after the bugfix. Now the TriangleMesh aircraft is returned in the pickList.
![with bugfix](https://user-images.githubusercontent.com/3943457/47817969-00198100-dd25-11e8-8568-f1b8305e791e.png)



If the code style is wrong or I have not considered some functionality, I apologize. Though I have been using WebWorldWind for a couple years now, this is my first attempt at contributing code to the project.