### PR TITLE
Add an zoom to mouse pointer effect

### DIFF
--- a/src/BasicWorldWindowController.js
+++ b/src/BasicWorldWindowController.js
@@ -105,11 +105,6 @@ define([
             this.tiltRecognizer = new TiltRecognizer(this.wwd, null);
             this.tiltRecognizer.addListener(this);
 
-            var self = this;
-            this.wwd.addEventListener('mousemove', function (event) {
-                self.pointerLocation = null;
-            }, false);
-
             // Establish the dependencies between gesture recognizers. The pan, pinch and rotate gesture may recognize
             // simultaneously with each other.
             this.panRecognizer.recognizeSimultaneouslyWith(this.pinchRecognizer);
@@ -146,6 +141,10 @@ define([
         // Intentionally not documented.
         BasicWorldWindowController.prototype.onGestureEvent = function (e) {
             var handled = WorldWindowController.prototype.onGestureEvent.call(this, e);
+
+            if (e.type === 'mousemove' || (e.pointerType === 'mouse' && e.type === 'pointermove')) {
+                this.pointerLocation = null;
+            }
 
             if (!handled) {
                 if (e.type === "wheel") {


### PR DESCRIPTION
### Description of the Change
When zooming in, the location of the mouse will move towards the center of the screen in such a way that the mouse will remain on that location.

When zooming out the location of the mouse will move away from the center of the screen in a reverse way from the zoom in effect. 

In case of a pinch, the mouse location is considered to be the center between the touch points.

This effect is enabled by default, but can be disabled.
