### PR TITLE
Add GeoJSONFeatureCollection and GeoJSONConstants to exports

### DIFF
--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -65,7 +65,9 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         './shapes/GeographicMesh',
         './projections/GeographicProjection',
         './shapes/GeographicText',
+        './formats/geojson/GeoJSONConstants',
         './formats/geojson/GeoJSONExporter',
+        './formats/geojson/GeoJSONFeatureCollection',
         './formats/geojson/GeoJSONGeometry',
         './formats/geojson/GeoJSONGeometryCollection',
         './formats/geojson/GeoJSONGeometryLineString',
@@ -343,7 +345,9 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
               GeographicMesh,
               GeographicProjection,
               GeographicText,
+              GeoJSONConstants,
               GeoJSONExporter,
+              GeoJSONFeatureCollection,
               GeoJSONGeometry,
               GeoJSONGeometryCollection,
               GeoJSONGeometryLineString,
@@ -858,7 +862,9 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         WorldWind['GeographicMesh'] = GeographicMesh;
         WorldWind['GeographicProjection'] = GeographicProjection;
         WorldWind['GeographicText'] = GeographicText;
+        WorldWind['GeoJSONConstants'] = GeoJSONConstants;
         WorldWind['GeoJSONExporter'] = GeoJSONExporter;
+        WorldWind['GeoJSONFeatureCollection'] = GeoJSONFeatureCollection;
         WorldWind['GeoJSONGeometry'] = GeoJSONGeometry;
         WorldWind['GeoJSONGeometryCollection'] = GeoJSONGeometryCollection;
         WorldWind['GeoJSONGeometryLineString'] = GeoJSONGeometryLineString;


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Add GeoJSONConstants and GeoJSONFeatureCollection to exports.

### Why Should This Be In Core?
We need access to GeoJSONConstants and GeoJSONFeatureCollection.
### Benefits

### Potential Drawbacks

### Applicable Issues