### PR TITLE
Corrected outdated references for BlueMarbleTimeSeries and WMTS examples

### DIFF
--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -43,7 +43,7 @@ requirejs(['./WorldWindShim',
         // Create the Blue Marble time series layer using REST tiles hosted at worldwind32.arc.nasa.gov.
         // Disable it until its images are cached, which is initiated below.
         var timeSeriesLayer = new WorldWind.BMNGRestLayer(
-           "https://worldwind.arc.nasa.gov/standalonedata/Earth/BlueMarble256");
+            "https://worldwind.arc.nasa.gov/standalonedata/Earth/BlueMarble256");
         timeSeriesLayer.enabled = false;
         timeSeriesLayer.showSpinner = true;
         wwd.addLayer(timeSeriesLayer);

--- a/examples/BlueMarbleTimeSeries.js
+++ b/examples/BlueMarbleTimeSeries.js
@@ -43,7 +43,7 @@ requirejs(['./WorldWindShim',
         // Create the Blue Marble time series layer using REST tiles hosted at worldwind32.arc.nasa.gov.
         // Disable it until its images are cached, which is initiated below.
         var timeSeriesLayer = new WorldWind.BMNGRestLayer(
-            "https://worldwind32.arc.nasa.gov/standalonedata/Earth/BlueMarble256");
+           "https://worldwind.arc.nasa.gov/standalonedata/Earth/BlueMarble256");
         timeSeriesLayer.enabled = false;
         timeSeriesLayer.showSpinner = true;
         wwd.addLayer(timeSeriesLayer);

--- a/examples/WMTS.js
+++ b/examples/WMTS.js
@@ -53,9 +53,9 @@ requirejs([
         }
 
         // Web Map Tiling Service information from
-        var serviceAddress = "https://tiles.geoservice.dlr.de/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities&VERSION=1.0.0";
-        // Layer displaying Global Hillshade based on GMTED2010
-        var layerIdentifier = "hillshade";
+        var serviceAddress = "https://map1.vis.earthdata.nasa.gov/wmts-webmerc/wmts.cgi?&request=GetCapabilities";
+        // Layer displaying Gridded Population of the World density forecast
+        var layerIdentifier = "GPW_Population_Density_2020";
 
         // Called asynchronously to parse and create the WMTS layer
         var createLayer = function (xmlDom) {


### PR DESCRIPTION
BlueMarbleTimeSeries and WMTS examples had outdated references of the data sources that are their focus.
- Time series data now resides in our website server instead of worldwind32 after server rearrangement
 - WMTS example now petitions from an EOSDIS NASA endpoint. Previous DLR service is denying requests now.

Note: Attempted to use the service:
https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/wmts.cgi?SERVICE=WMTS&request=GetCapabilities
but it produced errors probably due to our TODO items in WmtsLayer.