### PR TITLE
Retrievable pick point

### DIFF
--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -32,49 +32,80 @@
 requirejs(['./WorldWindShim',
         './LayerManager'],
     function (WorldWind, LayerManager) {
-    "use strict";
+        "use strict";
 
         // Tell WorldWind to log only warnings and errors.
-    WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
+        WorldWind.Logger.setLoggingLevel(WorldWind.Logger.LEVEL_WARNING);
 
-    // Create the WorldWindow.
-    var wwd = new WorldWind.WorldWindow("canvasOne");
+        // Create the WorldWindow.
+        var wwd = new WorldWind.WorldWindow("canvasOne");
 
-    // Create and add layers to the WorldWindow.
-    var layers = [
-        // Imagery layers.
-        {layer: new WorldWind.BMNGLayer(), enabled: true},
-        {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
-        {layer: new WorldWind.BingAerialLayer(null), enabled: false},
-        {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
-        {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
-        // Add atmosphere layer on top of all base layers.
-        {layer: new WorldWind.AtmosphereLayer(), enabled: true},
-        // WorldWindow UI layers.
-        {layer: new WorldWind.CompassLayer(), enabled: true},
-        {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},
-        {layer: new WorldWind.ViewControlsLayer(wwd), enabled: true}
-    ];
+        // Create and add layers to the WorldWindow.
+        var layers = [
+            // Imagery layers.
+            {layer: new WorldWind.BMNGLayer(), enabled: true},
+            {layer: new WorldWind.BMNGLandsatLayer(), enabled: false},
+            {layer: new WorldWind.BingAerialLayer(null), enabled: false},
+            {layer: new WorldWind.BingAerialWithLabelsLayer(null), enabled: false},
+            {layer: new WorldWind.BingRoadsLayer(null), enabled: false},
+            // Add atmosphere layer on top of all base layers.
+            {layer: new WorldWind.AtmosphereLayer(), enabled: true},
+            // WorldWindow UI layers.
+            {layer: new WorldWind.CompassLayer(), enabled: true},
+            {layer: new WorldWind.CoordinatesDisplayLayer(wwd), enabled: true},
+            {layer: new WorldWind.ViewControlsLayer(wwd), enabled: true}
+        ];
 
-    for (var l = 0; l < layers.length; l++) {
-        layers[l].layer.enabled = layers[l].enabled;
-        wwd.addLayer(layers[l].layer);
-    }
+        for (var l = 0; l < layers.length; l++) {
+            layers[l].layer.enabled = layers[l].enabled;
+            wwd.addLayer(layers[l].layer);
+        }
 
         // Create renderable layer to hold the Collada model.
-    var modelLayer = new WorldWind.RenderableLayer("Duck");
-    wwd.addLayer(modelLayer);
+        var modelLayer = new WorldWind.RenderableLayer("Duck");
+        wwd.addLayer(modelLayer);
+        var placemarkLayer = new WorldWind.RenderableLayer("Placemarks")
+        wwd.addLayer(placemarkLayer);
 
         // Define a position for locating the model.
-    var position = new WorldWind.Position(45, -100, 1000e3);
+        var position = new WorldWind.Position(45, -100, 1000e3);
         // Create a Collada loader and direct it to the desired directory and .dae file.
-    var colladaLoader = new WorldWind.ColladaLoader(position);
-    colladaLoader.init({dirPath: './collada_models/duck/'});
-    colladaLoader.load('duck.dae', function (scene) {
-        scene.scale = 5000;
-        modelLayer.addRenderable(scene); // Add the Collada model to the renderable layer within a callback.
-    });
+        var colladaLoader = new WorldWind.ColladaLoader(position);
+        colladaLoader.init({dirPath: './collada_models/duck/'});
+        var duckScene = null;
+        colladaLoader.load('duck.dae', function (scene) {
+            scene.scale = 5000;
+            modelLayer.addRenderable(scene); // Add the Collada model to the renderable layer within a callback.
+            duckScene = scene;
+        });
 
-    // Create a layer manager for controlling layer visibility.
-    var layerManager = new LayerManager(wwd);
-});
+        var placemarkAttributes = new WorldWind.PlacemarkAttributes(null);
+        placemarkAttributes.imageScale = 1;
+        placemarkAttributes.imageColor = WorldWind.Color.RED;
+        placemarkAttributes.labelAttributes.color = WorldWind.Color.YELLOW;
+        placemarkAttributes.drawLeaderLine = true;
+        placemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.RED;
+        placemarkAttributes.imageSource = WorldWind.configuration.baseUrl + "images/crosshair.png";
+        var handleClick = function (o) {
+            if (duckScene == null) {
+                return;
+            }
+            placemarkLayer.removeAllRenderables();
+            var clickPoint = wwd.canvasCoordinates(o.clientX, o.clientY);
+            var clickRay = wwd.rayThroughScreenPoint(clickPoint);
+            var intersections = [];
+            if (duckScene.computePointIntersections(wwd.globe, clickRay, intersections)) {
+                for (var i = 0, len = intersections.length; i < len; i++) {
+                    var placemark = new WorldWind.Placemark(intersections[i], true, null);
+                    placemark.altitudeMode = WorldWind.ABSOLUTE;
+                    placemark.attributes = placemarkAttributes;
+                    placemarkLayer.addRenderable(placemark);
+                }
+            }
+            wwd.redraw();
+        };
+        wwd.addEventListener("click", handleClick);
+
+        // Create a layer manager for controlling layer visibility.
+        var layerManager = new LayerManager(wwd);
+    });

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -80,8 +80,12 @@ requirejs(['./WorldWindShim',
             duckScene = scene;
         });
 
-        // Add place marks to intersection points with the ray extending from the eye point when the
-        // model is clicked.
+        // The following is an example of 3D ray intersaction with a COLLADA model.
+        // A ray will be generated extending from the camera "eye" point towards a point in the 
+        // COLLADA model where the user has clicked, then the intersections between this ray and the model
+        // will be computed and displayed.
+
+        // Add placemarks to visualize intersection points.
         var placemarkAttributes = new WorldWind.PlacemarkAttributes(null);
         placemarkAttributes.imageScale = 1;
         placemarkAttributes.imageColor = WorldWind.Color.RED;
@@ -89,16 +93,25 @@ requirejs(['./WorldWindShim',
         placemarkAttributes.drawLeaderLine = true;
         placemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.RED;
         placemarkAttributes.imageSource = WorldWind.configuration.baseUrl + "images/crosshair.png";
+        
+        // The next placemark will portray the closest intersection point to the camera, marked in a different color.
         var closestPlacemarkAttributes = new WorldWind.PlacemarkAttributes(placemarkAttributes);
         closestPlacemarkAttributes.imageColor = WorldWind.Color.GREEN;
         closestPlacemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.GREEN;
+        
+        // Add click event to trigger the generation of the ray and the computation of its intersctions with the COLLADA model.
         var handleClick = function (o) {
             if (duckScene == null) {
                 return;
             }
             placemarkLayer.removeAllRenderables();
+
+            // Obtain 3D ray that extends from the camera "eye" point towards the point where the user clicked on the COLLADA model.
             var clickPoint = wwd.canvasCoordinates(o.clientX, o.clientY);
             var clickRay = wwd.rayThroughScreenPoint(clickPoint);
+
+            // Compute intersection points between the model and the ray extending from the camera "eye" point.
+            // Note that this takes into account possible concavities in the model.
             var intersections = [];
             if (duckScene.computePointIntersections(wwd.globe, clickRay, intersections)) {
                 for (var i = 0, len = intersections.length; i < len; i++) {
@@ -112,8 +125,12 @@ requirejs(['./WorldWindShim',
                     placemarkLayer.addRenderable(placemark);
                 }
             }
+
+            // Redraw scene with the computed results.
             wwd.redraw();
         };
+
+        // Listen for mouse clicks to trigger the related event.
         wwd.addEventListener("click", handleClick);
 
         // Create a layer manager for controlling layer visibility.

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -26,7 +26,8 @@
  * PDF found in code  directory.
  */
 /**
- * Illustrates how to load and display a Collada 3D model onto the globe.
+ * Illustrates how to load and display a Collada 3D model onto the globe. Also shows how to calculate
+ * intersection points when you click on the model.
  */
 
 requirejs(['./WorldWindShim',
@@ -79,6 +80,8 @@ requirejs(['./WorldWindShim',
             duckScene = scene;
         });
 
+        // Add place marks to intersection points with the ray extending from the eye point when the
+        // model is clicked.
         var placemarkAttributes = new WorldWind.PlacemarkAttributes(null);
         placemarkAttributes.imageScale = 1;
         placemarkAttributes.imageColor = WorldWind.Color.RED;
@@ -86,6 +89,9 @@ requirejs(['./WorldWindShim',
         placemarkAttributes.drawLeaderLine = true;
         placemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.RED;
         placemarkAttributes.imageSource = WorldWind.configuration.baseUrl + "images/crosshair.png";
+        var closestPlacemarkAttributes = new WorldWind.PlacemarkAttributes(placemarkAttributes);
+        closestPlacemarkAttributes.imageColor = WorldWind.Color.GREEN;
+        closestPlacemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.GREEN;
         var handleClick = function (o) {
             if (duckScene == null) {
                 return;
@@ -98,7 +104,11 @@ requirejs(['./WorldWindShim',
                 for (var i = 0, len = intersections.length; i < len; i++) {
                     var placemark = new WorldWind.Placemark(intersections[i], true, null);
                     placemark.altitudeMode = WorldWind.ABSOLUTE;
-                    placemark.attributes = placemarkAttributes;
+                    if (i == 0) {
+                        placemark.attributes = closestPlacemarkAttributes;
+                    } else {
+                        placemark.attributes = placemarkAttributes;
+                    }
                     placemarkLayer.addRenderable(placemark);
                 }
             }

--- a/examples/Collada.js
+++ b/examples/Collada.js
@@ -93,12 +93,12 @@ requirejs(['./WorldWindShim',
         placemarkAttributes.drawLeaderLine = true;
         placemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.RED;
         placemarkAttributes.imageSource = WorldWind.configuration.baseUrl + "images/crosshair.png";
-        
+
         // The next placemark will portray the closest intersection point to the camera, marked in a different color.
         var closestPlacemarkAttributes = new WorldWind.PlacemarkAttributes(placemarkAttributes);
         closestPlacemarkAttributes.imageColor = WorldWind.Color.GREEN;
         closestPlacemarkAttributes.leaderLineAttributes.outlineColor = WorldWind.Color.GREEN;
-        
+
         // Add click event to trigger the generation of the ray and the computation of its intersctions with the COLLADA model.
         var handleClick = function (o) {
             if (duckScene == null) {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,75 +1,74 @@
 // Karma configuration
 // Generated on Thu Feb 04 2016 14:07:41 GMT+0100 (CET)
 
-module.exports = function(config) {
-  config.set({
+module.exports = function (config) {
+    config.set({
 
-    // base path that will be used to resolve all patterns (eg. files, exclude)
-    basePath: '',
-
-
-    // frameworks to use
-    // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
-    frameworks: ['jasmine', 'requirejs'],
+        // base path that will be used to resolve all patterns (eg. files, exclude)
+        basePath: '',
 
 
-    // list of files / patterns to load in the browser
-    files: [
-      'test/test-main.js',
-      {pattern: 'test/**/*.test.js', included: false},
-      {pattern: 'src/**/*.js', included: false},
-      {pattern: 'examples/data/KML_Samples.kml', included: false},
-      {pattern: 'test/formats/geotiff/*.tif', included: false},
-      {pattern: 'test/ogc/wcs/*.xml', included: false},
-      {pattern: 'test/formats/aaigrid/*.asc', included: false}
-    ],
+        // frameworks to use
+        // available frameworks: https://npmjs.org/browse/keyword/karma-adapter
+        frameworks: ['jasmine', 'requirejs'],
 
 
-    // list of files to exclude
-    exclude: [
-    ],
+        // list of files / patterns to load in the browser
+        files: [
+            'test/test-main.js',
+            {pattern: 'test/**/*.test.js', included: false},
+            {pattern: 'src/**/*.js', included: false},
+            {pattern: 'examples/data/KML_Samples.kml', included: false},
+            {pattern: 'test/formats/geotiff/*.tif', included: false},
+            {pattern: 'test/ogc/wcs/*.xml', included: false},
+            {pattern: 'test/formats/aaigrid/*.asc', included: false},
+            {pattern: 'test/formats/collada/*.dae', included: false}
+        ],
 
 
-    // preprocess matching files before serving them to the browser
-    // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
-    preprocessors: {
-    },
+        // list of files to exclude
+        exclude: [],
 
 
-    // test results reporter to use
-    // possible values: 'dots', 'progress'
-    // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: ['progress'],
+        // preprocess matching files before serving them to the browser
+        // available preprocessors: https://npmjs.org/browse/keyword/karma-preprocessor
+        preprocessors: {},
 
 
-    // web server port
-    port: 9876,
+        // test results reporter to use
+        // possible values: 'dots', 'progress'
+        // available reporters: https://npmjs.org/browse/keyword/karma-reporter
+        reporters: ['progress'],
 
 
-    // enable / disable colors in the output (reporters and logs)
-    colors: true,
+        // web server port
+        port: 9876,
 
 
-    // level of logging
-    // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-    logLevel: config.LOG_INFO,
+        // enable / disable colors in the output (reporters and logs)
+        colors: true,
 
 
-    // enable / disable watching file and executing tests whenever any file changes
-    autoWatch: true,
+        // level of logging
+        // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
+        logLevel: config.LOG_INFO,
 
 
-    // start these browsers
-    // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['PhantomJS'],
+        // enable / disable watching file and executing tests whenever any file changes
+        autoWatch: true,
 
 
-    // Continuous Integration mode
-    // if true, Karma captures browsers, runs the tests and exits
-    singleRun: false,
+        // start these browsers
+        // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
+        browsers: ['PhantomJS'],
 
-    // Concurrency level
-    // how many browser should be started simultaneous
-    concurrency: Infinity
-  })
+
+        // Continuous Integration mode
+        // if true, Karma captures browsers, runs the tests and exits
+        singleRun: false,
+
+        // Concurrency level
+        // how many browser should be started simultaneous
+        concurrency: Infinity
+    })
 };

--- a/src/formats/collada/ColladaScene.js
+++ b/src/formats/collada/ColladaScene.js
@@ -33,6 +33,8 @@ define([
         '../../error/ArgumentError',
         '../../shaders/BasicTextureProgram',
         '../../util/Color',
+        '../../globe/Globe',
+        '../../geom/Line',
         '../../util/Logger',
         '../../geom/Matrix',
         '../../geom/Position',
@@ -44,6 +46,8 @@ define([
     function (ArgumentError,
               BasicTextureProgram,
               Color,
+              Globe,
+              Line,
               Logger,
               Matrix,
               Position,
@@ -71,6 +75,10 @@ define([
 
             Renderable.call(this);
 
+            this._currentData = {
+                expired: true,
+                transformedPoints: []
+            };
             // Documented in defineProperties below.
             this._position = position;
 
@@ -155,6 +163,7 @@ define([
                     return this._position;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._position = value;
                 }
             },
@@ -183,6 +192,7 @@ define([
                     return this._meshes;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._meshes = value;
                 }
             },
@@ -253,6 +263,7 @@ define([
                     return this._xRotation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._xRotation = value;
                 }
             },
@@ -267,6 +278,7 @@ define([
                     return this._yRotation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._yRotation = value;
                 }
             },
@@ -281,6 +293,7 @@ define([
                     return this._zRotation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._zRotation = value;
                 }
             },
@@ -295,6 +308,7 @@ define([
                     return this._xTranslation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._xTranslation = value;
                 }
             },
@@ -309,6 +323,7 @@ define([
                     return this._yTranslation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._yTranslation = value;
                 }
             },
@@ -323,6 +338,7 @@ define([
                     return this._zTranslation;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._zTranslation = value;
                 }
             },
@@ -337,6 +353,7 @@ define([
                     return this._scale;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._scale = value;
                 }
             },
@@ -351,6 +368,7 @@ define([
                     return this._placePoint;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._placePoint = value;
                 }
             },
@@ -491,6 +509,7 @@ define([
                     return this._computedNormals;
                 },
                 set: function (value) {
+                    this._currentData.expired = true;
                     this._computedNormals = value;
                 }
             }
@@ -603,6 +622,70 @@ define([
             return this;
         };
 
+        ColladaScene.prototype.computeTransformedPoints = function (mesh) {
+            var vtxs = mesh.vertices;
+            var points = [];
+            if (mesh.indexedRendering) {
+                var idxs = mesh.indices;
+                for (var i = 0, len = idxs.length; i < len; i += 3) {
+                    for (var j = 0; j < 3; j++) {
+                        var vtxOfs = idxs[i + j] * 3;
+                        var vtx = new Vec3(vtxs[vtxOfs], vtxs[vtxOfs + 1], vtxs[vtxOfs + 2]);
+                        vtx.multiplyByMatrix(this._transformationMatrix);
+                        points.push(vtx);
+                    }
+                }
+            } else {
+                for (var i = 0, len = vtxs.length; i < len; i += 3) {
+                    var vtx = new Vec3(vtxs[i], vtxs[i + 1], vtxs[i + 2]);
+                    vtx.multiplyByMatrix(this._transformationMatrix);
+                    points.push(vtx);
+                }
+            }
+
+            return points;
+        };
+
+        ColladaScene.prototype.computePointIntersections = function (globe, pointRay, results) {
+            if (!globe) {
+                throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "ColladaScene",
+                    "computePointIntersections", "missingGlobe"));
+            }
+
+            if (!pointRay) {
+                throw new ArgumentError(
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "ColladaScene",
+                        "computePointIntersections", "missingRay"));
+            }
+
+            if (!results) {
+                throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "ColladaScene",
+                    "computePointIntersections", "missingResults"));
+            }
+
+            var computeTransforms = this._currentData.transformedPoints.length <= this._entities.length;
+            if (computeTransforms) {
+                this._currentData.transformedPoints = [];
+            }
+            for (var i = 0, len = this._entities.length; i < len; i++) {
+                var mesh = this._entities[i].mesh;
+                if (computeTransforms) {
+                    this._currentData.transformedPoints.push(this.computeTransformedPoints(mesh));
+                }
+                var intersectionPoints = [];
+                if (WWMath.computeTriangleListIntersection(pointRay,
+                    this._currentData.transformedPoints[i], intersectionPoints)) {
+                    for (var j = 0, iLen = intersectionPoints.length; j < iLen; j++) {
+                        var position = new Position(0, 0, 0);
+                        globe.computePositionFromPoint(intersectionPoints[j][0],
+                            intersectionPoints[j][1], intersectionPoints[j][2], position);
+                        results.push(position);
+                    }
+                }
+            }
+            return results.length > 0;
+        };
+
         // Internal. Intentionally not documented.
         ColladaScene.prototype.renderOrdered = function (dc) {
             this.drawOrderedScene(dc);
@@ -624,6 +707,9 @@ define([
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.beginDrawing = function (dc) {
+            if (this._currentData.expired) {
+                this._currentData.transformedPoints = [];
+            }
             var gl = dc.currentGlContext;
             var gpuResourceCache = dc.gpuResourceCache;
 
@@ -693,6 +779,7 @@ define([
                             newUvs[newUvIdx + 1] = uvs[uvOfs + 1];
                         }
                     }
+
                     var normal = WWMath.computeTriangleNormal(triangle[0], triangle[1], triangle[2]);
                     for (var j = 0; j < 3; j++) {
                         var newIdx = (i + j) * 3;
@@ -961,10 +1048,15 @@ define([
             gl.disableVertexAttribArray(2);
             program.loadApplyLighting(gl, 0);
             program.loadTextureEnabled(gl, false);
+            this._currentData.expired = false;
         };
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.computeTransformationMatrix = function (globe) {
+            if (!this._currentData.expired) {
+                return;
+            }
+
             this._transformationMatrix.setToIdentity();
 
             this._transformationMatrix.multiplyByLocalCoordinateTransform(this._placePoint, globe);
@@ -982,6 +1074,9 @@ define([
 
         // Internal. Intentionally not documented.
         ColladaScene.prototype.computeNormalMatrix = function () {
+            if (!this._currentData.expired) {
+                return;
+            }
             this._transformationMatrix.extractRotationAngles(this._tmpVector);
             this._normalTransformMatrix.setToIdentity();
             this._normalTransformMatrix.multiplyByRotation(-1, 0, 0, this._tmpVector[0]);

--- a/src/geom/Matrix.js
+++ b/src/geom/Matrix.js
@@ -1500,8 +1500,7 @@ define([
                     for (j = ii; j <= i - 1; j += 1) {
                         sum -= A[i][j] * b[j];
                     }
-                }
-                else if (sum != 0.0) {
+                } else if (sum != 0.0) {
                     ii = i;
                 }
 
@@ -1548,8 +1547,7 @@ define([
 
                 if (big == 0.0) {
                     return 0.0; // Matrix is singular if the entire row contains zero.
-                }
-                else {
+                } else {
                     vv[i] = 1.0 / big;
                 }
             }
@@ -1926,6 +1924,17 @@ define([
             result[2] = z / w;
 
             return true;
+        };
+
+        /**
+         * Returns a string representation of this matrix.
+         * @returns {String} A string representation of this matrix.
+         */
+        Matrix.prototype.toString = function () {
+            return "(" + this[0] + ", " + this[1] + ", " + this[2] + ", " + this[3] + ")\n" +
+                "(" + this[4] + ", " + this[5] + ", " + this[6] + ", " + this[7] + ")\n" +
+                "(" + this[8] + ", " + this[9] + ", " + this[10] + ", " + this[11] + ")\n" +
+                "(" + this[12] + ", " + this[13] + ", " + this[14] + ", " + this[15] + ")";
         };
 
         return Matrix;

--- a/src/shapes/PlacemarkAttributes.js
+++ b/src/shapes/PlacemarkAttributes.js
@@ -61,9 +61,9 @@ define([
             this._imageScale = attributes ? attributes._imageScale : 1;
             this._imageSource = attributes ? attributes._imageSource : null;
             this._depthTest = attributes ? attributes._depthTest : true;
-            this._labelAttributes = attributes ? attributes._labelAttributes : new TextAttributes(null);
+            this._labelAttributes = attributes ? new TextAttributes(attributes._labelAttributes) : new TextAttributes(null);
             this._drawLeaderLine = attributes ? attributes._drawLeaderLine : false;
-            this._leaderLineAttributes = attributes ? attributes._leaderLineAttributes : new ShapeAttributes(null);
+            this._leaderLineAttributes = attributes ? new ShapeAttributes(attributes._leaderLineAttributes) : new ShapeAttributes(null);
 
             /**
              * Indicates whether this object's state key is invalid. Subclasses must set this value to true when their

--- a/src/util/WWMath.js
+++ b/src/util/WWMath.js
@@ -258,6 +258,32 @@ define([
                 }
             },
 
+            computeTriangleListIntersection: function (line, points, results) {
+                if (!line) {
+                    throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "WWMath",
+                        "computeIndexedTrianglesIntersection", "missingLine"));
+                }
+
+                if (!points) {
+                    throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "WWMath",
+                        "computeIndexedTrianglesIntersection", "missingPoints"));
+                }
+
+                if (!results) {
+                    throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "WWMath",
+                        "computeIndexedTrianglesIntersection", "missingResults"));
+                }
+                var iPoint = new Vec3(0, 0, 0);
+                for (var i = 0, len = points.length; i < len; i += 3) {
+                    if (WWMath.computeTriangleIntersection(line, points[i], points[i + 1], points[i + 2], iPoint)) {
+                        results.push(iPoint);
+                        iPoint = new Vec3(0, 0, 0);
+                    }
+                }
+
+                return results.length > 0;
+            },
+
             computeIndexedTrianglesIntersection: function (line, points, indices, results) {
                 if (!line) {
                     throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "WWMath",

--- a/src/util/WWMath.js
+++ b/src/util/WWMath.js
@@ -258,6 +258,16 @@ define([
                 }
             },
 
+            /**
+             * Computes the Cartesian intersection point(s) of a specified line with a non-indexed list of
+             * triangle vertices.
+             * @param {Line} line The line for which to compute the intersection(s).
+             * @param {Vec3[]} points The list of triangle vertices arranged such that each
+             * 3-tuple, (i,i+1,i+2), specifies a triangle.
+             * @param {Vec3[]} results The Cartesian intersection point(s) if any.
+             * @returns {boolean} true if the line intersects any triangle, otherwise false
+             * @throws {ArgumentError} If any of the arguments is not supplied.
+             */
             computeTriangleListIntersection: function (line, points, results) {
                 if (!line) {
                     throw new ArgumentError(Logger.logMessage(Logger.LEVEL_SEVERE, "WWMath",

--- a/test/formats/collada/ColladaScene.test.js
+++ b/test/formats/collada/ColladaScene.test.js
@@ -27,7 +27,6 @@
  */
 define([
     'src/formats/collada/ColladaScene',
-    'test/CustomMatchers.test',
     'src/globe/ElevationModel',
     'src/globe/Globe',
     'src/geom/Line',
@@ -35,7 +34,7 @@ define([
     'src/geom/Position',
     'src/projections/ProjectionWgs84',
     'src/geom/Vec3'
-], function (ColladaScene, CustomMatchers, ElevationModel, Globe, Line, Matrix, Position, ProjectionWgs84, Vec3) {
+], function (ColladaScene, ElevationModel, Globe, Line, Matrix, Position, ProjectionWgs84, Vec3) {
     "use strict";
 
     describe("ColladaScene calculation and data manipulation testing", function () {
@@ -100,6 +99,7 @@ define([
                 expect(mesh.uvs[i]).toBe(expectedUvs[i]);
             }
         });
+
         it("Should properly compute intersection points with a ray", function () {
             var colladaLoader = new WorldWind.ColladaLoader(new Position(44, -96, 10000));
             colladaLoader.init({dirPath: '../base/test/formats/collada/'});
@@ -124,10 +124,17 @@ define([
                 intersectionsFound = scene.computePointIntersections(globe, pointRay, intersections);
                 expect(intersectionsFound).toBe(true);
                 expect(intersections.length).toBe(2);
-                var i1 = new Position(43.088776730634535, -95.18631436743668, 29685.22045946613);
-                var i2 = new Position(43.30646919618773, -95.39472743244926, 15659.079434582456);
-                expect(intersections[0]).toBeCloseToPosition(i1, 7, 7, 7);
-                expect(intersections[1]).toBeCloseToPosition(i2, 7, 7, 7);
+                var i0 = new Position(43.088776730634535, -95.18631436743668, 29685.22045946613);
+                var i1 = new Position(43.30646919618773, -95.39472743244926, 15659.079434582456);
+                // Using toBeCloseToPosition may be causing weird unreliability
+                // expect(intersections[0]).toBeCloseToPosition(i1, 7, 7, 7);
+                // expect(intersections[1]).toBeCloseToPosition(i2, 7, 7, 7);
+                expect(intersections[0].latitude).toBeCloseTo(i0.latitude, 7);
+                expect(intersections[0].longitude).toBeCloseTo(i0.longitude, 7);
+                expect(intersections[0].altitude).toBeCloseTo(i0.altitude, 7);
+                expect(intersections[1].latitude).toBeCloseTo(i1.latitude, 7);
+                expect(intersections[1].longitude).toBeCloseTo(i1.longitude, 7);
+                expect(intersections[1].altitude).toBeCloseTo(i1.altitude, 7);
                 expect(function () {
                     scene.computePointIntersections(null, pointRay, intersections);
                 }).toThrow();

--- a/test/formats/collada/ColladaScene.test.js
+++ b/test/formats/collada/ColladaScene.test.js
@@ -26,12 +26,20 @@
  * PDF found in code  directory.
  */
 define([
+    'src/formats/collada/ColladaScene',
+    'test/CustomMatchers.test',
+    'src/globe/ElevationModel',
+    'src/globe/Globe',
+    'src/geom/Line',
+    'src/geom/Matrix',
     'src/geom/Position',
-    'src/formats/collada/ColladaScene'
-], function (Position, ColladaScene) {
+    'src/projections/ProjectionWgs84',
+    'src/geom/Vec3'
+], function (ColladaScene, CustomMatchers, ElevationModel, Globe, Line, Matrix, Position, ProjectionWgs84, Vec3) {
     "use strict";
 
     describe("ColladaScene calculation and data manipulation testing", function () {
+
         it("Should properly calculate new normals and create proper vertex order", function () {
             var indices = [0, 1, 2, 3, 2, 1, 4, 5, 6, 7, 6, 5, 8, 9, 10, 11, 10, 9, 12, 13, 14, 15, 14, 13, 16, 17, 18,
                 19, 18, 17, 20, 21, 22, 23, 22, 21];
@@ -91,6 +99,45 @@ define([
             for (i = 0, len = mesh.uvs.length; i < len; i++) {
                 expect(mesh.uvs[i]).toBe(expectedUvs[i]);
             }
+        });
+        it("Should properly compute intersection points with a ray", function () {
+            var colladaLoader = new WorldWind.ColladaLoader(new Position(44, -96, 10000));
+            colladaLoader.init({dirPath: '../base/test/formats/collada/'});
+            colladaLoader.load('bad_normals.dae', function (scene) {
+                scene.scale = 5000;
+                var transformation = new Matrix(-522.6423163382683, 3454.283622726456, -3576.9777274867624, -4577455.847120033,
+                    -5.898059818402838e-13, 3596.6807208022315, 3473.3107826121095, 4415038.196148923,
+                    4972.609476841367, 363.05983855741573, -375.9555086098537, -481109.9962739506,
+                    0, 0, 0, 1);
+                scene._transformationMatrix = transformation;
+                var origin = new Vec3(-12416258.178691395, 10375578.62866234, -2479066.981438789);
+                var direction = new Vec3(0.8649427998779189, -0.4976765198118716, 0.06474592317119227);
+                var pointRay = new Line(origin, direction);
+                var intersections = [];
+                var globe = new Globe(new WorldWind.ElevationModel(), new WorldWind.ProjectionWgs84());
+                var intersectionsFound = scene.computePointIntersections(globe, pointRay, intersections);
+                expect(intersectionsFound).toBe(false);
+                expect(intersections.length).toBe(0);
+                origin = new Vec3(-5117511.089956183, 4226332.17224274, -193896.81490928633);
+                direction = new Vec3(0.862977304871313, 0.24683805077319543, -0.4408414090889536);
+                pointRay = new Line(origin, direction);
+                intersectionsFound = scene.computePointIntersections(globe, pointRay, intersections);
+                expect(intersectionsFound).toBe(true);
+                expect(intersections.length).toBe(2);
+                var i1 = new Position(43.088776730634535, -95.18631436743668, 29685.22045946613);
+                var i2 = new Position(43.30646919618773, -95.39472743244926, 15659.079434582456);
+                expect(intersections[0]).toBeCloseToPosition(i1, 7, 7, 7);
+                expect(intersections[1]).toBeCloseToPosition(i2, 7, 7, 7);
+                expect(function () {
+                    scene.computePointIntersections(null, pointRay, intersections);
+                }).toThrow();
+                expect(function () {
+                    scene.computePointIntersections(globe, null, intersections);
+                }).toThrow();
+                expect(function () {
+                    scene.computePointIntersections(globe, pointRay, null);
+                }).toThrow();
+            });
         });
     });
 });

--- a/test/formats/collada/bad_normals.dae
+++ b/test/formats/collada/bad_normals.dae
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+	<asset>
+		<created>2020-05-21T08:37:06Z</created>
+		<modified>2020-05-21T08:37:06Z</modified>
+		<up_axis>Z_UP</up_axis>
+	</asset>
+	<library_geometries>
+		<geometry id="ID_201700003257.dae3">
+			<mesh>
+				<source id="ID_201700003257.dae3-positions">
+					<float_array id="ID_201700003257.dae3-positions-array" count="24">25.8881 2.22867 13.4721 25.8881 2.22867 0.5465 11.6699 -23.2139 13.4721 11.6699 -23.2139 1.2027 -25.8881 -2.2244 13.4721 -25.8881 -2.2244 0.6561 -11.6621 23.2139 13.4721 -11.6621 23.2139 0</float_array>
+					<technique_common>
+						<accessor count="8" source="#ID_201700003257.dae3-positions-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<source id="ID_201700003257.dae3-normals">
+					<float_array id="ID_201700003257.dae3-normals-array" count="3">0 0 1</float_array>
+					<technique_common>
+						<accessor count="1" source="#ID_201700003257.dae3-normals-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<vertices id="ID_201700003257.dae3-vertices">
+					<input semantic="POSITION" source="#ID_201700003257.dae3-positions"/>
+				</vertices>
+				<triangles count="8" material="ID_201700003257.dae3material">
+					<input offset="0" semantic="VERTEX" source="#ID_201700003257.dae3-vertices"/>
+					<input offset="1" semantic="NORMAL" source="#ID_201700003257.dae3-normals"/>
+					<p>1 0 0 0 2 0 1 0 2 0 3 0 3 0 2 0 4 0 3 0 4 0 5 0 5 0 4 0 6 0 5 0 6 0 7 0 7 0 6 0 0 0 7 0 0 0 1 0</p>
+				</triangles>
+			</mesh>
+		</geometry>
+		<geometry id="ID_201700003257.dae4">
+			<mesh>
+				<source id="ID_201700003257.dae4-positions">
+					<float_array id="ID_201700003257.dae4-positions-array" count="12">11.6699 -23.2139 1.2027 -11.6621 23.2139 0 -25.8881 -2.2244 0.6561 25.8881 2.22867 0.5465</float_array>
+					<technique_common>
+						<accessor count="4" source="#ID_201700003257.dae4-positions-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<source id="ID_201700003257.dae4-normals">
+					<float_array id="ID_201700003257.dae4-normals-array" count="3">0 0 1</float_array>
+					<technique_common>
+						<accessor count="1" source="#ID_201700003257.dae4-normals-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<vertices id="ID_201700003257.dae4-vertices">
+					<input semantic="POSITION" source="#ID_201700003257.dae4-positions"/>
+				</vertices>
+				<triangles count="2" material="ID_201700003257.dae4material">
+					<input offset="0" semantic="VERTEX" source="#ID_201700003257.dae4-vertices"/>
+					<input offset="1" semantic="NORMAL" source="#ID_201700003257.dae4-normals"/>
+					<p>1 0 0 0 2 0 0 0 1 0 3 0</p>
+				</triangles>
+			</mesh>
+		</geometry>
+		<geometry id="ID_201700003257.dae5">
+			<mesh>
+				<source id="ID_201700003257.dae5-positions">
+					<float_array id="ID_201700003257.dae5-positions-array" count="12">-11.6621 23.2139 13.4721 11.6699 -23.2139 13.4721 -25.8881 -2.2244 13.4721 25.8881 2.22867 13.4721</float_array>
+					<technique_common>
+						<accessor count="4" source="#ID_201700003257.dae5-positions-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<source id="ID_201700003257.dae5-normals">
+					<float_array id="ID_201700003257.dae5-normals-array" count="3">0 0 1</float_array>
+					<technique_common>
+						<accessor count="1" source="#ID_201700003257.dae5-normals-array" stride="3">
+							<param name="X" type="float"/>
+							<param name="Y" type="float"/>
+							<param name="Z" type="float"/>
+						</accessor>
+					</technique_common>
+				</source>
+				<vertices id="ID_201700003257.dae5-vertices">
+					<input semantic="POSITION" source="#ID_201700003257.dae5-positions"/>
+				</vertices>
+				<triangles count="2" material="ID_201700003257.dae5material">
+					<input offset="0" semantic="VERTEX" source="#ID_201700003257.dae5-vertices"/>
+					<input offset="1" semantic="NORMAL" source="#ID_201700003257.dae5-normals"/>
+					<p>1 0 0 0 2 0 0 0 1 0 3 0</p>
+				</triangles>
+			</mesh>
+		</geometry>
+	</library_geometries>
+	<library_effects>
+		<effect id="ID_201700003257.dae0effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae0material">
+			<instance_effect url="#ID_201700003257.dae0effect"/>
+		</material>
+	</library_materials>
+	<library_effects>
+		<effect id="ID_201700003257.dae1effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae1material">
+			<instance_effect url="#ID_201700003257.dae1effect"/>
+		</material>
+	</library_materials>
+	<library_effects>
+		<effect id="ID_201700003257.dae2effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae2material">
+			<instance_effect url="#ID_201700003257.dae2effect"/>
+		</material>
+	</library_materials>
+	<library_effects>
+		<effect id="ID_201700003257.dae3effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae3material">
+			<instance_effect url="#ID_201700003257.dae3effect"/>
+		</material>
+	</library_materials>
+	<library_effects>
+		<effect id="ID_201700003257.dae4effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae4material">
+			<instance_effect url="#ID_201700003257.dae4effect"/>
+		</material>
+	</library_materials>
+	<library_effects>
+		<effect id="ID_201700003257.dae5effect">
+			<profile_COMMON>
+				<technique sid="common">
+					<phong>
+						<diffuse>
+							<color>0.929412 0.760784 0.611765 1</color>
+						</diffuse>
+					</phong>
+				</technique>
+			</profile_COMMON>
+		</effect>
+	</library_effects>
+	<library_materials>
+		<material id="ID_201700003257.dae5material">
+			<instance_effect url="#ID_201700003257.dae5effect"/>
+		</material>
+	</library_materials>
+	<library_visual_scenes>
+		<visual_scene id="Multipatch-Converted-Scene">
+			<node id="ID_201700003257.dae">
+				<translate>0 0 0</translate>
+				<instance_geometry url="#ID_201700003257.dae3">
+					<bind_material>
+						<technique_common>
+							<instance_material symbol="ID_201700003257.dae3material" target="#ID_201700003257.dae3material"/>
+						</technique_common>
+					</bind_material>
+				</instance_geometry>
+				<instance_geometry url="#ID_201700003257.dae4">
+					<bind_material>
+						<technique_common>
+							<instance_material symbol="ID_201700003257.dae4material" target="#ID_201700003257.dae4material"/>
+						</technique_common>
+					</bind_material>
+				</instance_geometry>
+				<instance_geometry url="#ID_201700003257.dae5">
+					<bind_material>
+						<technique_common>
+							<instance_material symbol="ID_201700003257.dae5material" target="#ID_201700003257.dae5material"/>
+						</technique_common>
+					</bind_material>
+				</instance_geometry>
+			</node>
+		</visual_scene>
+	</library_visual_scenes>
+	<scene>
+		<instance_visual_scene url="#Multipatch-Converted-Scene"/>
+	</scene>
+</COLLADA>


### PR DESCRIPTION
Adds the ability to determine where a user has clicked on a 3D model in a WorldWind Scene. Also fixes a minor bug in PlacemarkAttributes: When cloning another set of attributes, some sub-attributes were being referenced directly instead of cloned themselves.