### PR TITLE
Added 'prepare' npm script

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ provides many simple [examples](https://github.com/NASAWorldWind/WebWorldWind/tr
 
 [Install NodeJS](https://nodejs.org). The build is known to work with Node.js 12.18.0 LTS.
 
-- `npm install` downloads WorldWind's dependencies
+- `npm install` downloads WorldWind's dependencies and builds everything
 
 - `npm run build` builds everything
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "build": "grunt",
     "clean": "grunt clean",
     "doc": "grunt jsdoc",
+    "prepare": "npm run build",
     "test": "grunt karma",
     "test:watch": "karma start karma.conf.js"
   },


### PR DESCRIPTION
### Description of the Change
Added `prepare` script for the benefit of developers that pull WebWW's repo from GitHub as dependency.

Reference: https://docs.npmjs.com/misc/scripts#prepublish-and-prepare