### PR TITLE
reversed event handler execution

### DIFF
--- a/src/WorldWindow.js
+++ b/src/WorldWindow.js
@@ -414,9 +414,9 @@ define([
             if (!entry) {
                 entry = {
                     listeners: [],
-                    callback: function (event) { // calls listeners in reverse registration order
+                    callback: function (event) { // calls listeners in registration order
                         event.worldWindow = thisWorldWindow;
-                        for (var i = 0, len = entry.listeners.length; i < len; i++) {
+                        for (var i = entry.listeners.length - 1; i >= 0; i--) {
                             entry.listeners[i](event);
                         }
                     }


### PR DESCRIPTION
**Note:** Filling out this template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the
maintainer's discretion.

### Description of the Change
Reverses the order in which event handlers are processed, originally they were processed in reverse registration order, they are now processed in registration order.

### Why Should This Be In Core?
The camera altitude was always one scroll event off the correct altitude, this change modified that so the event handler responsible for updating the internal altitude state runs before any user added event handlers run. 

### Benefits
Ensures WW internal event handlers are run with priority and that the internal data state is correctly updated before user added event handlers run.

### Potential Drawbacks
If user applications depend on this reverse execution order their functionality could be broken.

### Applicable Issues