### PR TITLE
Fix picking of wrong SurfaceShape

### DIFF
--- a/src/shapes/SurfaceShapeTile.js
+++ b/src/shapes/SurfaceShapeTile.js
@@ -223,6 +223,21 @@ define([
                 shape.renderToTexture(dc, ctx2D, xScale, yScale, xOffset, yOffset);
             }
 
+            // Remove semi-transparent pixels, which may contain wrong pick color due to anti-aliasing
+            // TODO Disable anti-aliasing of canvas stroke in renderToTexture instead of this hack, when it will be supported by browsers
+            if (dc.pickingMode) {
+                var imageData = ctx2D.getImageData(0, 0, canvas.width, canvas.height);
+                for (var i = 3, n = canvas.width * canvas.height * 4; i < n; i += 4) {
+                    if (imageData.data[i] < 255) {
+                        imageData.data[i - 3] = 0;
+                        imageData.data[i - 2] = 0;
+                        imageData.data[i - 1] = 0;
+                        imageData.data[i] = 0;
+                    }
+                }
+                ctx2D.putImageData(imageData, 0, 0);
+            }
+
             this.gpuCacheKey = this.getCacheKey();
 
             var gpuResourceCache = dc.gpuResourceCache;


### PR DESCRIPTION
### Description of the Change
This change disable anti-aliasing for `SurfaceShape` objects during picking so that a shape's anti-aliased pixel colors are not confused with the "pick" colors of other nearby shapes, otherwise, the wrong shape can be selected by the pick operation.

### Why Should This Be In Core?
Picking is an essential feature of the SDK.

### Benefits
This fix makes picking an individual `SurfaceShape` among many nearby shapes predicable.

### Potential Drawbacks
Picking performance