### PR TITLE
Improve and simplify Mercator layers management

### DIFF
--- a/src/layer/BMNGLandsatLayer.js
+++ b/src/layer/BMNGLandsatLayer.js
@@ -49,11 +49,8 @@ define([
          */
         var BMNGLandsatLayer = function () {
             // This LevelSet configuration captures the Landsat resolution of 1.38889E-04 degrees/pixel
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, "Blue Marble & Landsat",
                 Sector.FULL_SPHERE, new Location(45, 45), 12, "image/jpeg", "BMNGLandsat256", 256, 256);
-
-            this.displayName = "Blue Marble & Landsat";
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder("https://worldwind25.arc.nasa.gov/wms",
                 "BlueMarble-200405,esat", "", "1.3.0");

--- a/src/layer/BMNGLayer.js
+++ b/src/layer/BMNGLayer.js
@@ -52,11 +52,8 @@ define([
          */
         var BMNGLayer = function (layerName) {
             // This LevelSet configuration captures the Blue Marble resolution of 4.166666667E-03 degrees/pixel
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, "Blue Marble",
                 Sector.FULL_SPHERE, new Location(45, 45), 7, "image/jpeg", layerName || "BMNG256", 256, 256);
-
-            this.displayName = "Blue Marble";
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder("https://worldwind25.arc.nasa.gov/wms",
                 layerName || "BlueMarble-200405", "", "1.3.0");

--- a/src/layer/BingTiledImageLayer.js
+++ b/src/layer/BingTiledImageLayer.js
@@ -29,21 +29,15 @@
  * @exports BingTiledImageLayer
  */
 define([
-        '../geom/Angle',
         '../util/Color',
-        '../geom/Location',
-        '../util/Offset',
         '../shapes/ScreenImage',
-        '../geom/Sector',
-        '../layer/MercatorTiledImageLayer'
+        '../layer/MercatorTiledImageLayer',
+        '../WorldWind'
     ],
-    function (Angle,
-              Color,
-              Location,
-              Offset,
+    function (Color,
               ScreenImage,
-              Sector,
-              MercatorTiledImageLayer) {
+              MercatorTiledImageLayer,
+              WorldWind) {
         "use strict";
 
         /**
@@ -58,18 +52,16 @@ define([
          * @param {String} displayName This layer's display name.
          */
         var BingTiledImageLayer = function (displayName) {
-            this.imageSize = 256;
-
-            MercatorTiledImageLayer.call(this,
-                new Sector(-85.05, 85.05, -180, 180), new Location(85.05, 180), 23, "image/jpeg", displayName,
-                this.imageSize, this.imageSize);
-
-            this.displayName = displayName;
+            MercatorTiledImageLayer.call(this, displayName, 23, "image/jpeg", displayName, 256, 1);
 
             // TODO: Picking is enabled as a temporary measure for screen credit hyperlinks to work (see Layer.render)
             this.pickEnabled = true;
 
             this.detectBlankImages = true;
+
+            // Set the detail control so the resolution is a close match 
+            // to the resolution on the Bing maps website
+            this.detailControl = 1.25;
         };
 
         // Internal use only. Intentionally not documented.
@@ -88,16 +80,6 @@ define([
             }
         };
 
-        // Overridden from TiledImageLayer.
-        BingTiledImageLayer.prototype.createTopLevelTiles = function (dc) {
-            this.topLevelTiles = [];
-
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 1));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 1));
-        };
-
         BingTiledImageLayer.prototype.renderLogo = function (dc) {
             if (!BingTiledImageLayer.logoImage) {
                 BingTiledImageLayer.logoImage = new ScreenImage(WorldWind.configuration.bingLogoPlacement,
@@ -111,11 +93,6 @@ define([
                 BingTiledImageLayer.logoImage.render(dc);
                 BingTiledImageLayer.logoLastFrameTime = dc.timestamp;
             }
-        };
-
-        // Determines the Bing map size for a specified level number.
-        BingTiledImageLayer.prototype.mapSizeForLevel = function (levelNumber) {
-            return 256 << (levelNumber + 1);
         };
 
         return BingTiledImageLayer;

--- a/src/layer/DigitalGlobeTiledImageLayer.js
+++ b/src/layer/DigitalGlobeTiledImageLayer.js
@@ -29,20 +29,14 @@
  * @exports DigitalGlobeTiledImageLayer
  */
 define([
-        '../geom/Angle',
         '../error/ArgumentError',
         '../util/Color',
-        '../geom/Location',
         '../util/Logger',
-        '../geom/Sector',
         '../layer/MercatorTiledImageLayer'
     ],
-    function (Angle,
-              ArgumentError,
+    function (ArgumentError,
               Color,
-              Location,
               Logger,
-              Sector,
               MercatorTiledImageLayer) {
         "use strict";
 
@@ -73,12 +67,7 @@ define([
                         "The access token is null or undefined."));
             }
 
-            this.imageSize = 256;
-            displayName = displayName || "Digital Globe";
-
-            MercatorTiledImageLayer.call(this,
-                new Sector(-85.05, 85.05, -180, 180), new Location(85.05, 180), 19, "image/jpeg", displayName,
-                this.imageSize, this.imageSize);
+            MercatorTiledImageLayer.call(this, displayName || "Digital Globe", 19, "image/jpeg", displayName, 256, 1);
 
             /**
              * The map ID identifying the dataset displayed by this layer.
@@ -94,7 +83,6 @@ define([
             this.accessToken = accessToken;
             //"pk.eyJ1IjoiZGlnaXRhbGdsb2JlIiwiYSI6IjljZjQwNmEyMTNhOWUyMWM5NWUzYWIwOGNhYTY2ZDViIn0.Ju3tOUUUc0C_gcCSAVpFIA";
 
-            this.displayName = displayName;
             // TODO: Picking is enabled as a temporary measure for screen credit hyperlinks to work (see Layer.render)
             this.pickEnabled = true;
 
@@ -154,21 +142,6 @@ define([
             if (this.inCurrentFrame) {
                 dc.screenCreditController.addCredit("\u00A9 Digital Globe", Color.DARK_GRAY);
             }
-        };
-
-        // Overridden from TiledImageLayer.
-        DigitalGlobeTiledImageLayer.prototype.createTopLevelTiles = function (dc) {
-            this.topLevelTiles = [];
-
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 0, 1));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 0));
-            this.topLevelTiles.push(this.createTile(null, this.levels.firstLevel(), 1, 1));
-        };
-
-        // Determines the Bing map size for a specified level number.
-        DigitalGlobeTiledImageLayer.prototype.mapSizeForLevel = function (levelNumber) {
-            return 256 << (levelNumber + 1);
         };
 
         return DigitalGlobeTiledImageLayer;

--- a/src/layer/LandsatRestLayer.js
+++ b/src/layer/LandsatRestLayer.js
@@ -63,10 +63,8 @@ define([
         var LandsatRestLayer = function (serverAddress, pathToData, displayName) {
             var cachePath = WWUtil.urlPath(serverAddress + "/" + pathToData);
 
-            TiledImageLayer.call(this, Sector.FULL_SPHERE, new Location(36, 36), 10, "image/png", cachePath, 512, 512);
+            TiledImageLayer.call(this, displayName, Sector.FULL_SPHERE, new Location(36, 36), 10, "image/png", cachePath, 512, 512);
 
-            this.displayName = displayName;
-            this.pickEnabled = false;
             this.urlBuilder = new LevelRowColumnUrlBuilder(serverAddress, pathToData);
         };
 

--- a/src/layer/Layer.js
+++ b/src/layer/Layer.js
@@ -28,10 +28,7 @@
 /**
  * @exports Layer
  */
-define([
-        '../util/Logger'
-    ],
-    function (Logger) {
+define([], function () {
         "use strict";
 
         /**
@@ -40,6 +37,7 @@ define([
          * @constructor
          * @classdesc Provides an abstract base class for layer implementations. This class is not meant to be instantiated
          * directly.
+         * @param {String} displayName This layer's display name.
          */
         var Layer = function (displayName) {
 
@@ -48,7 +46,7 @@ define([
              * @type {String}
              * @default "Layer"
              */
-            this.displayName = displayName ? displayName : "Layer";
+            this.displayName = displayName || "Layer";
 
             /**
              * Indicates whether to display this layer.

--- a/src/layer/RestTiledImageLayer.js
+++ b/src/layer/RestTiledImageLayer.js
@@ -72,7 +72,7 @@ define([
         var RestTiledImageLayer = function (serverAddress, pathToData, displayName, configuration) {
             var cachePath = WWUtil.urlPath(serverAddress + "/" + pathToData);
 
-            TiledImageLayer.call(this,
+            TiledImageLayer.call(this, displayName,
                 (configuration && configuration.sector) || Sector.FULL_SPHERE,
                 (configuration && configuration.levelZeroTileDelta) || new Location(45, 45),
                 (configuration && configuration.numLevels) || 5,
@@ -81,8 +81,6 @@ define([
                 (configuration && configuration.tileWidth) || 256,
                 (configuration && configuration.tileHeight) || 256);
 
-            this.displayName = displayName;
-            this.pickEnabled = false;
             this.urlBuilder = new LevelRowColumnUrlBuilder(serverAddress, pathToData);
         };
 

--- a/src/layer/TiledImageLayer.js
+++ b/src/layer/TiledImageLayer.js
@@ -73,6 +73,7 @@ define([
          * Layers of this type are by default not pickable. Their pick-enabled flag is initialized to false.
          *
          * @augments Layer
+         * @param {String} displayName This layer's display name.
          * @param {Sector} sector The sector this layer covers.
          * @param {Location} levelZeroDelta The size in latitude and longitude of level zero (lowest resolution) tiles.
          * @param {Number} numLevels The number of levels to define for the layer. Each level is successively one power
@@ -87,7 +88,7 @@ define([
          * null or undefined, or if the specified number of levels, tile width or tile height is less than 1.
          *
          */
-        var TiledImageLayer = function (sector, levelZeroDelta, numLevels, imageFormat, cachePath, tileWidth, tileHeight) {
+        var TiledImageLayer = function (displayName, sector, levelZeroDelta, numLevels, imageFormat, cachePath, tileWidth, tileHeight) {
             if (!sector) {
                 throw new ArgumentError(
                     Logger.logMessage(Logger.LEVEL_SEVERE, "TiledImageLayer", "constructor", "missingSector"));
@@ -123,7 +124,7 @@ define([
                         "The specified tile width or height is less than one."));
             }
 
-            Layer.call(this, "Tiled Image Layer");
+            Layer.call(this, displayName || "Tiled Image Layer");
 
             this.retrievalImageFormat = imageFormat;
             this.cachePath = cachePath;

--- a/src/layer/WmsLayer.js
+++ b/src/layer/WmsLayer.js
@@ -82,11 +82,8 @@ define([
                 cachePath = cachePath + timeString;
             }
 
-            TiledImageLayer.call(this, config.sector, config.levelZeroDelta, config.numLevels, config.format,
+            TiledImageLayer.call(this, config.title, config.sector, config.levelZeroDelta, config.numLevels, config.format,
                 cachePath, config.size, config.size);
-
-            this.displayName = config.title;
-            this.pickEnabled = false;
 
             this.urlBuilder = new WmsUrlBuilder(config.service, config.layerNames, config.styleNames, config.version,
                 timeString);

--- a/src/layer/heatmap/HeatMapLayer.js
+++ b/src/layer/heatmap/HeatMapLayer.js
@@ -69,9 +69,7 @@ define([
         this.tileWidth = 256;
         this.tileHeight = 256;
 
-        TiledImageLayer.call(this, new Sector(-90, 90, -180, 180), new Location(45, 45), numLevels || 18, 'image/png', 'HeatMap' + WWUtil.guid(), this.tileWidth, this.tileHeight);
-
-        this.displayName = displayName;
+        TiledImageLayer.call(this, displayName, new Sector(-90, 90, -180, 180), new Location(45, 45), numLevels || 18, 'image/png', 'HeatMap' + WWUtil.guid(), this.tileWidth, this.tileHeight);
 
         var data = {};
         for (var lat = -90; lat <= 90; lat++) {


### PR DESCRIPTION
### Description of the Changes
Refactor MercatorTiledImageLayer to include all general initialization, such as: sector, zero level delta, display name, image size, detectBlankImages and mapSizeForLevel calculation into parent constructor. This makes child layers avoiding unnecessary copy-paste code.
Added first level offset parameter which allows to skip several top levels to avoid displaying one tile over whole globe. 
Added alternative way of determining tile URL by overriding getImageSourceUrl function. This allows to create additional online layers by setting several parameters in constructor and overriding one function with URL builder instead of separate URL builder creation.

### Why Should This Be In Core?
This feature simplify adding new typical online layers such as Google, OSM, OTM. Wiki, etc by only specifying core parameters without unnecessary copy-paste of the same logic.
This approach already implemented in Java and will be implemented in Android.

### Benefits
Simple Mercator online sources creation.

### Potential Drawbacks
Less flexibility of constructor.
