### PR TITLE
Renamed getEndianness function to better convey its behavior

### DIFF
--- a/src/formats/geotiff/GeoTiffReader.js
+++ b/src/formats/geotiff/GeoTiffReader.js
@@ -200,7 +200,7 @@ define([
                 return;
             }
 
-            this.getEndianness();
+            this.initEndiannessFromFile();
 
             if (!this.isTiffFileType()) {
                 throw new AbstractError(
@@ -216,7 +216,7 @@ define([
         };
 
         // Get byte order of the geotiff file. Internal use only.
-        GeoTiffReader.prototype.getEndianness = function () {
+        GeoTiffReader.prototype.initEndiannessFromFile = function () {
             var byteOrderValue = GeoTiffUtil.getBytes(this.geoTiffData, 0, 2, this.isLittleEndian);
             if (byteOrderValue === 0x4949) {
                 this._isLittleEndian = true;
@@ -226,7 +226,7 @@ define([
             }
             else {
                 throw new AbstractError(
-                    Logger.logMessage(Logger.LEVEL_SEVERE, "GeoTiffReader", "getEndianness", "invalidByteOrderValue"));
+                    Logger.logMessage(Logger.LEVEL_SEVERE, "GeoTiffReader", "initEndiannessFromFile", "invalidByteOrderValue"));
             }
         };
 


### PR DESCRIPTION
### Description of the Change

Renamed `getEndianness()` function to `initEndiannessFromFile()` since the original name conveys that it's a read-only function, when it's not.

Addresses #834 