### PR TITLE
Reverted WKT coordinate parsing to first read latitude and then longitude

### DIFF
--- a/examples/WKT.html
+++ b/examples/WKT.html
@@ -35,10 +35,12 @@
                     </button>
                 </span>
             </div>
-            <h4>WKT</h4>
-            <div>
-                <input type="text" id="wkt" />
-                <input type="button" id="showWkt" value="Show" />
+            <h4>Custom WKT entry</h4>
+            <div class="input-group">
+                <input type="text" class="form-control" id="wkt" />
+                <span class="input-group-btn">
+                    <input type="button" class="btn btn-primary" id="showWkt" value="Show" />
+                </span>
             </div>
         </div>
         <div class="col-sm-9" id="globe">

--- a/examples/WKT.html
+++ b/examples/WKT.html
@@ -39,7 +39,7 @@
             <div class="input-group">
                 <input type="text" class="form-control" id="wkt" />
                 <span class="input-group-btn">
-                    <input type="button" class="btn btn-primary" id="showWkt" value="Show" />
+                    <input id="showWkt" class="btn btn-primary" type="button" value="Show"/>
                 </span>
             </div>
         </div>

--- a/examples/WKT.js
+++ b/examples/WKT.js
@@ -93,7 +93,7 @@ requirejs(['./WorldWindShim',
         wwd.addLayer(customCallbackLayer);
 
         // Allow for parsing of Well-Known Text from the app's text box (entered by the user).
-        var wktLayer = new WorldWind.RenderableLayer('WKT Custom');
+        var wktLayer = new WorldWind.RenderableLayer('Custom WKT');
         $('#showWkt').click(function () {
             new WorldWind.Wkt($('#wkt').val()).load(null, null, wktLayer);
         });

--- a/src/formats/wkt/geom/WktObject.js
+++ b/src/formats/wkt/geom/WktObject.js
@@ -105,9 +105,9 @@ define([
      */
     WktObject.prototype.addCoordinates = function (coordinates) {
         if (this._is3d) {
-            this.coordinates.push(new Position(coordinates[1], coordinates[0], coordinates[2] || 0));
+            this.coordinates.push(new Position(coordinates[0], coordinates[1], coordinates[2] || 0));
         } else {
-            this.coordinates.push(new Location(coordinates[1], coordinates[0]));
+            this.coordinates.push(new Location(coordinates[0], coordinates[1]));
         }
     };
 

--- a/test/formats/wkt/WktTokens.test.js
+++ b/test/formats/wkt/WktTokens.test.js
@@ -57,7 +57,7 @@ define([
     describe("WktTokens", function () {
         describe("Point", function () {
             it('correctly parses 2D point', function () {
-                var point2D = 'POINT (50 14.5)';
+                var point2D = 'POINT (14.5 50)';
                 var wktObjects = new WktTokens(point2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -66,7 +66,7 @@ define([
             });
 
             it('correctly parses 3D point', function () {
-                var point3D = 'POINT Z(50 14.5 13)';
+                var point3D = 'POINT Z(14.5 50 13)';
                 var wktObjects = new WktTokens(point3D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -75,7 +75,7 @@ define([
             });
 
             it('correctly ignores the LRS for 2D point', function () {
-                var point2DLrs = 'POINT M (50 14.5 10)';
+                var point2DLrs = 'POINT M (14.5 50 10)';
                 var wktObjects = new WktTokens(point2DLrs).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -84,7 +84,7 @@ define([
             });
 
             it('correctly ignores the LRS for 3D point', function () {
-                var point3DLrs = 'POINT MZ (50 14.5 10 13)';
+                var point3DLrs = 'POINT MZ (14.5 50 10 13)';
                 var wktObjects = new WktTokens(point3DLrs).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -95,7 +95,7 @@ define([
 
         describe('Polygon', function () {
             it('correctly parses 2D polygon', function () {
-                var polygon2D = 'POLYGON ((-70 40, -80 45, -90 40))';
+                var polygon2D = 'POLYGON ((40 -70, 45 -80, 40 -90))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -105,7 +105,7 @@ define([
             });
 
             it('correctly parses 3D polygon with inner boundaries', function(){
-                var polygon = 'POLYGON Z ((-70 40 10, -80 45 10, -90 40 10), (-75 42 10, 44 -78 10, 42 -73 10))';
+                var polygon = 'POLYGON Z ((40 -70 10, 45 -80 10, 40 -90 10), (42 -75 10, 44 -78 10, 42 -73 10))';
                 var wktObjects = new WktTokens(polygon).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -114,7 +114,7 @@ define([
             });
 
             it('correctly ignores LRS for 2D polygon', function () {
-                var polygon2D = 'POLYGON M((-70 40 10, -80 45 10, -90 40 10))';
+                var polygon2D = 'POLYGON M((40 -70 10, 45 -80 10, 40 -90 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -124,7 +124,7 @@ define([
             });
 
             it('correctly parses 3D polygon', function () {
-                var polygon2D = 'POLYGON Z ((-70 40 10, -80 45 10, -90 40 10))';
+                var polygon2D = 'POLYGON Z ((40 -70 10, 45 -80 10, 40 -90 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -134,7 +134,7 @@ define([
             });
 
             it('correctly ignores LRS for 3D polygon', function () {
-                var polygon2D = 'POLYGON MZ ((-70 40 10, -80 45 10, -90 40 10))';
+                var polygon2D = 'POLYGON MZ ((40 -70 10, 45 -80 10, 40 -90 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -155,7 +155,7 @@ define([
             });
 
             it('correctly parses 2D line string', function () {
-                var polygon2D = 'LINESTRING ((-75 33, -80 37, -85 33))';
+                var polygon2D = 'LINESTRING ((33 -75, 37 -80, 33 -85))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -165,7 +165,7 @@ define([
             });
 
             it('correctly ignores LRS for 2D line string', function () {
-                var polygon2D = 'LINESTRING M((-75 33 10, -80 37 10, -85 33 10))';
+                var polygon2D = 'LINESTRING M((33 -75 10, 37 -80 10, 33 -85 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -175,7 +175,7 @@ define([
             });
 
             it('correctly parses 3D line string', function () {
-                var polygon2D = 'LINESTRINGZ((-75 33 10, -80 37 10, -85 33 10))';
+                var polygon2D = 'LINESTRINGZ((33 -75 10, 37 -80 10, 33 -85 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -185,7 +185,7 @@ define([
             });
 
             it('correctly ignores LRS for 3D line string', function () {
-                var polygon2D = 'LINESTRING MZ((-75 33 10 10, -80 37 10 10, -85 33 10 10))';
+                var polygon2D = 'LINESTRING MZ((33 -75 10 10, 37 -80 10 10, 33 -85 10 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -197,7 +197,7 @@ define([
 
         describe('Triangle', function () {
             it('correctly parses 2D triangle', function () {
-                var polygon2D = 'TRIANGLE ((-70 40, -80 45, -90 40))';
+                var polygon2D = 'TRIANGLE ((40 -70, 45 -80, 40 -90))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -207,7 +207,7 @@ define([
             });
 
             it('correctly ignores LRS for 2D triangle', function () {
-                var polygon2D = 'TRIANGLE M((-70 40 10, -80 45 10, -90 40 10))';
+                var polygon2D = 'TRIANGLE M((40 -70 10, 45 -80 10, 40 -90 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -217,7 +217,7 @@ define([
             });
 
             it('correctly parses 3D triangle', function () {
-                var polygon2D = 'TRIANGLE Z((-70 40 10, -80 45 10, -90 40 10))';
+                var polygon2D = 'TRIANGLE Z((40 -70 10, 45 -80 10, 40 -90 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -227,7 +227,7 @@ define([
             });
 
             it('correctly ignores LRS for 3D triangle', function () {
-                var polygon2D = 'TRIANGLE MZ((-70 40 10 10, -80 45 10 10, -90 40 10 10))';
+                var polygon2D = 'TRIANGLE MZ((40 -70 10 10, 45 -80 10 10, 40 -90 10 10))';
                 var wktObjects = new WktTokens(polygon2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -239,7 +239,7 @@ define([
 
         describe('MultiPoint', function () {
             it('correctly parses 2D point', function () {
-                var point2D = 'MULTIPOINT ((49.3 17),(49 -17))';
+                var point2D = 'MULTIPOINT ((17 49.3),(-17 49))';
                 var wktObjects = new WktTokens(point2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -250,7 +250,7 @@ define([
             });
 
             it('correctly parses 3D point', function () {
-                var point2D = 'MULTIPOINT Z((49.3 17 10),(49 -17 1))';
+                var point2D = 'MULTIPOINT Z((17 49.3 10),(-17 49 1))';
                 var wktObjects = new WktTokens(point2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -261,7 +261,7 @@ define([
             });
 
             it('correctly ignores the LRS for 2D point', function () {
-                var point2DLrs = 'MULTIPOINT M((49.3 17 10),(49 -17 1))';
+                var point2DLrs = 'MULTIPOINT M((17 49.3 10),(-17 49 1))';
                 var wktObjects = new WktTokens(point2DLrs).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -272,7 +272,7 @@ define([
             });
 
             it('correctly ignores the LRS for 3D point', function () {
-                var point2D = 'MULTIPOINT MZ((49.3 17 10 1),(49 -17 1 100))';
+                var point2D = 'MULTIPOINT MZ((17 49.3 10 1),(-17 49 1 100))';
                 var wktObjects = new WktTokens(point2D).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -285,7 +285,7 @@ define([
 
         describe('MultiLineString', function () {
             it('correctly parses 2D Multi Line String', function(){
-                var multiLineString = 'MULTILINESTRING ((-70 38, -75 42, -80 38),(-65 43, -70 47, -75 43))';
+                var multiLineString = 'MULTILINESTRING ((38 -70, 42 -75, 38 -80),(43 -65, 47 -70, 43 -75))';
                 var wktObjects = new WktTokens(multiLineString).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -298,7 +298,7 @@ define([
             });
 
             it('correctly parses 2D Multi Line String with LRS', function(){
-                var multiLineString = 'MULTILINESTRING M((-70 38 10, -75 42 10, -80 38 10),(-65 43 10, -70 47 10, -75 43 10))';
+                var multiLineString = 'MULTILINESTRING M((38 -70 10, 42 -75 10, 38 -80 10),(43 -65 10, 47 -70 10, 43 -75 10))';
                 var wktObjects = new WktTokens(multiLineString).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -311,7 +311,7 @@ define([
             });
 
             it('correctly parses 3D Line String', function(){
-                var multiLineString = 'MULTILINESTRING Z((-70 38 10, -75 42 10, -80 38 10),(-65 43 10, -70 47 10, -75 43 10))';
+                var multiLineString = 'MULTILINESTRING Z((38 -70 10, 42 -75 10, 38 -80 10),(43 -65 10, 47 -70 10, 43 -75 10))';
                 var wktObjects = new WktTokens(multiLineString).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -324,7 +324,7 @@ define([
             });
 
             it('correctly parses 3D Line String with LRS', function(){
-                var multiLineString = 'MULTILINESTRING MZ((-70 38 10 12, -75 42 10 12, -80 38 10 12),(-65 43 10 12, -70 47 10 12, -75 43 10 12))';
+                var multiLineString = 'MULTILINESTRING MZ((38 -70 10 12, 42 -75 10 12, 38 -80 10 12),(43 -65 10 12, 47 -70 10 12, 43 -75 10 12))';
                 var wktObjects = new WktTokens(multiLineString).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -339,7 +339,7 @@ define([
 
         describe('MultiPolygon', function () {
             it('correctly parses 2D Multi polygon', function(){
-                var multiPolygon = 'MULTIPOLYGON (((-60 50, -70 55, -80 50)),((-60 30, -70 35, -80 30)))';
+                var multiPolygon = 'MULTIPOLYGON (((50 -60, 55 -70, 50 -80)),((30 -60, 35 -70, 30 -80)))';
                 var wktObjects = new WktTokens(multiPolygon).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -355,7 +355,7 @@ define([
             });
 
             it('correctly parses 3D Multi polygon with inner boundaries', function(){
-                var multiPolygon = 'MULTIPOLYGON Z (((-60 50 10, -70 55 10, -80 50 10)),((-70 40 10, -80 45 10, -90 40 10), (-75 42 10, 44 -78 10, 42 -73 10)))';
+                var multiPolygon = 'MULTIPOLYGON Z (((50 -60 10, 55 -70 10, 50 -80 10)),((40 -70 10, 45 -80 10, 40 -90 10), (42 -75 10, 44 -78 10, 42 -73 10)))';
                 var wktObjects = new WktTokens(multiPolygon).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -367,7 +367,7 @@ define([
             });
 
             it('correctly parses 2D Multi polygon with LRS', function(){
-                var multiPolygon = 'MULTIPOLYGON M (((-60 50 10, -70 55 10, -80 50 10)),((-60 30 10, -70 35 10, -80 30 10)))';
+                var multiPolygon = 'MULTIPOLYGON M (((50 -60 10, 55 -70 10, 50 -80 10)),((30 -60 10, 35 -70 10, 30 -80 10)))';
                 var wktObjects = new WktTokens(multiPolygon).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -380,7 +380,7 @@ define([
             });
 
             it('correctly parses 3D Multi Polygon', function(){
-                var multiPolygon = 'MULTIPOLYGON Z (((-60 50 10, -70 55 10, -80 50 10)),((-60 30 10, -70 35 10, -80 30 10)))';
+                var multiPolygon = 'MULTIPOLYGON Z (((50 -60 10, 55 -70 10, 50 -80 10)),((30 -60 10, 35 -70 10, 30 -80 10)))';
                 var wktObjects = new WktTokens(multiPolygon).objects();
 
                 expect(wktObjects.length).toBe(1);
@@ -393,7 +393,7 @@ define([
             });
 
             it('correctly parses 3D Multi Polygon with LRS', function(){
-                var multiPolygon = 'MULTIPOLYGON MZ (((-60 50 10 10, -70 55 10 10, -80 50 10 10)),((-60 30 10 10, -70 35 10 10, -80 30 10 10)))';
+                var multiPolygon = 'MULTIPOLYGON MZ (((50 -60 10 10, 55 -70 10 10, 50 -80 10 10)),((30 -60 10 10, 35 -70 10 10, 30 -80 10 10)))';
                 var wktObjects = new WktTokens(multiPolygon).objects();
 
                 expect(wktObjects.length).toBe(1);


### PR DESCRIPTION
### Description of the Change

- Changed the way `WktObject` reads coordinates from long-lat to lat-long.
- Adjusted the WKT unit test accordingly.
- Modified WKT example styling to have the WKT string entry textbox and "Show" button to be visually in line with the Destination textbox.

Tested proper functioning of WKT example and the `WktTokens` unit test.

### Why Should This Be In Core?

In #780 the order of geographical coordinates was changed to be read with longitude before latitude for WKT strings.

This introduced errors in the Well-Known Text example:

- The `MULTIPOLYGON` green triangles are no longer displayed.
- Custom WKT entry no longer works.

It seems that there's ambiguity on the precedence of latitude or longitude in WKT. OpenGeospatial's specification on Simple Feature Access, section 7 [[ > ](https://portal.ogc.org/files/?artifact_id=25355)], which is mentioned as the reference spec for our format implementation in `src/formats/wkt/README.MD`, doesn't state any precedence either for latitude and longitude.

The following discussion provides what is the most reasonable course of action in my estimation:

> For the axis order for any coordinate reference system where EPSG is the authority, you should use their registry https://epsg.org/home.html

> For example for epsg:4326 (https://epsg.org/crs/wkt/id/4326).
> The WKT output shows that for EPSG:4326 the axis order is lat/long

````
GEODCRS["WGS 84",
  DATUM["World Geodetic System 1984",
    ELLIPSOID["WGS 84",6378137,298.257223563,LENGTHUNIT["metre",1.0]]],
  CS[ellipsoidal,2],
    AXIS["latitude",north,ORDER[1]],
    AXIS["longitude",east,ORDER[2]],
    ANGLEUNIT["degree",0.01745329252],
  ID["EPSG",4326]]
````

> Most EPSG geographic geographic coordinate systems follow the latitude then longitude, coordinate axis order, following the default of ISO 6709 Standard representation of geographic point location by coordinates

https://gis.stackexchange.com/questions/366853/wkt-coordinate-inner-order-long-lat

This change aligns WKT parsing with the ISO standard, making the WKT example to properly work again.

### Benefits

The WKT example works as intended. WKT parsing is now in compliance with ISO 6709 [ [>](https://www.iso.org/standard/39242.html) ], and in line with other geographical string formats within the library.

### Potential Drawbacks

There seems to be ambiguity on how WKT parsing should work. Other products do give precedence to longitude before latitude, but in my estimation, it's appropriate that we align with the ISO standard, considering that the OpenGeospatial spec is ambiguous in regards to how WKT should be parsed if CRS is not provided.