### PR TITLE
Fix tiled elevation coverage absent resource list analysis

### DIFF
--- a/src/globe/TiledElevationCoverage.js
+++ b/src/globe/TiledElevationCoverage.js
@@ -571,18 +571,15 @@ define(['../util/AbsentResourceList',
 
         // Intentionally not documented.
         TiledElevationCoverage.prototype.retrieveTileImage = function (tile) {
-            if (this.currentRetrievals.indexOf(tile.tileKey) < 0) {
-
-                if (this.currentRetrievals.length > this.retrievalQueueSize) {
-                    return;
-                }
+            if (this.currentRetrievals.length < this.retrievalQueueSize
+                && this.currentRetrievals.indexOf(tile.tileKey) < 0
+                && !this.absentResourceList.isResourceAbsent(tile.tileKey)) {
 
                 var url = this.resourceUrlForTile(tile, this.retrievalImageFormat),
                     xhr = new XMLHttpRequest(),
                     elevationCoverage = this;
 
-                if (!url)
-                    return;
+                if (!url) return;
 
                 xhr.open("GET", url, true);
                 xhr.responseType = 'arraybuffer';


### PR DESCRIPTION
### Description of the Change
Added analysis of absent resource list missed in the code.

### Why Should This Be In Core?
There is a bug in code, which fills absent resource list but never check it.

### Benefits
Missed elevation tiles will not be requested too often.

### Potential Drawbacks
None

### Applicable Issues
None