### PR TITLE
Added version consistency check before each build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "url": "https://github.com/NASAWorldWind/WebWorldWind.git"
   },
   "scripts": {
-    "build": "grunt",
+    "build": "npm run check-version && grunt",
+    "check-version": "node tools/versioncheck.js",
     "clean": "grunt clean",
     "doc": "grunt jsdoc",
     "prepare": "npm run build",

--- a/src/WorldWind.js
+++ b/src/WorldWind.js
@@ -592,10 +592,9 @@ define([ // PLEASE KEEP ALL THIS IN ALPHABETICAL ORDER BY MODULE NAME (not direc
         var WorldWind = {
             /**
              * The WorldWind version number.
-             * @default "0.9.0"
              * @constant
              */
-            VERSION: "0.9.0",
+            VERSION: "0.11.0",
 
             // PLEASE KEEP THE ENTRIES BELOW IN ALPHABETICAL ORDER
             /**

--- a/tools/versioncheck.js
+++ b/tools/versioncheck.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+// Path to the project root from the script's location
+const projectRoot = path.resolve(__dirname, '..');
+
+function getVersionFromPackageJson() {
+    try {
+        const packageJsonPath = path.join(projectRoot, 'package.json');
+        const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
+        console.log(`Version number in package.json is: ${packageJson.version}`);
+        return packageJson.version;
+    } catch (error) {
+        console.error(`An error occurred while reading or parsing package.json: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+function getVersionFromJsFile(filePath) {
+    try {
+        const jsFilePath = path.join(projectRoot, filePath);
+        const jsFileContent = fs.readFileSync(jsFilePath, 'utf8');
+        const regex = /VERSION:\s*"([^"]+)"/;
+        const match = regex.exec(jsFileContent);
+        if (!match) {
+            console.error(`Version number not found in ${filePath}`);
+            process.exit(1);
+        }
+        console.log(`Version number in ${filePath} is: ${match[1]}`);
+        return match[1];
+    } catch (error) {
+        console.error(`An error occurred while reading ${filePath}: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+function compareVersions(version1, version2) {
+    if (version1 === version2) {
+        console.log('Version numbers are consistent between package.json and WorldWind.js');
+    } else {
+        console.error(`ERROR: Version numbers do not match between package.json and WorldWind.js`);
+        process.exit(1);
+    }
+}
+
+const packageVersion = getVersionFromPackageJson();
+const jsWorldWindVersion = getVersionFromJsFile('src/WorldWind.js');
+compareVersions(packageVersion, jsWorldWindVersion);


### PR DESCRIPTION
### Description of the Change
Additionally to the version number located in package.json which provides us with versioning for the npm package, we internally store a VERSION property in the main WorldWind object. Since the latter predated the publishing of the npm package and due requiring manual updating, it has not been in sync with the package.json value.

- This change adds a script that verifies consistency between these two values before performing a build, canceling the build if the check fails. 
- The value in WorldWind.js is updated to reflect the numbering as found in the npm package and GitHub's releases.

Tested regex in line 23 of the script at https://regex101.com/. I also tested an assortment of version numbers and nonsensical strings.

### Why Should This Be In Core?
It provides the developer the means to ensure that version numbers are consistent across the project without incurring in breaking changes to the WorldWind object.

### Benefits
Simple way to maintain version consistency between the two files where the value is stored.

### Potential Drawbacks
For future releases, It still requires manually updating the version number in WorldWind.VERSION. Since automatically rewriting it with each build could be considered an antipattern, manual updating is deemed acceptable.